### PR TITLE
Updated Makefile.am to have Ompi 1.6's new file name

### DIFF
--- a/mpi_adio/Makefile.am
+++ b/mpi_adio/Makefile.am
@@ -49,7 +49,7 @@ README.patching \
 patches/mpich2/mpich2-1.2.1p1-plfs-prep.patch \
 patches/mpich2/mpich2-1.4.1p1-plfs-prep.patch \
 patches/openmpi/ompi-1.4.x-plfs-prep.patch \
-patches/openmpi/ompi-1.6-plfs-prep.patch \
+patches/openmpi/ompi-1.6.x-plfs-prep.patch \
 patches/openmpi/optimized-panfs-plfs \
 patches/openmpi/optimized-panfs-plfs.conf \
 scripts/make_ad_plfs_patch


### PR DESCRIPTION
I forgot to update mpi_adio's Makefile.am to reflect the change in file name of Open MPI's 1.6 prep patch. 'make dist' fails without this change.
