### PR TITLE
Truncate no longer occurs always if O_CREAT is specified and always if creat is called explicitly

### DIFF
--- a/src/Container.cpp
+++ b/src/Container.cpp
@@ -1807,7 +1807,7 @@ Container::createHelper(const string& expanded_path, const string& hostname,
     }
     existing_container = res;
     //creat specifies that we truncate if the file exists
-    if (existing_container){
+    if (existing_container && flags & O_TRUNC){
         res = Container::Truncate(expanded_path, 0);
         if (res < 0){
             mlog(CON_CRIT, "Failed to truncate file %s : %s",

--- a/src/ContainerFS.cpp
+++ b/src/ContainerFS.cpp
@@ -28,6 +28,7 @@ int
 ContainerFileSystem::create(const char *logical, mode_t mode,
                             int flags, pid_t pid)
 {
+    flags = O_WRONLY|O_CREAT|O_TRUNC;
     return container_create(logical, mode, flags, pid);
 }
 


### PR DESCRIPTION
Truncate no longer occurs always if O_CREAT is specified and always if creat is called explicitly
