### PR TITLE
Put patching of ad_opencoll.c back in to the relevant prep patches.

### DIFF
--- a/mpi_adio/patches/mpich2/mpich2-1.4.1p1-plfs-prep.patch
+++ b/mpi_adio/patches/mpich2/mpich2-1.4.1p1-plfs-prep.patch
@@ -60,6 +60,18 @@ diff -Naur mpich2-1.4.1p1/src/mpi/romio/adio/common/ad_fstype.c mpich2-1.4.1p1-p
      if (file_system == ADIO_HFS) {
  #ifndef ROMIO_HFS
  	*error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+diff -Naur mpich2-1.4.1p1/src/mpi/romio/adio/common/ad_opencoll.c mpich2-1.4.1p1-plfs/src/mpi/romio/adio/common/ad_opencoll.c
+--- mpich2-1.4.1p1/src/mpi/romio/adio/common/ad_opencoll.c	2009-05-06 15:18:23.000000000 -0600
++++ mpich2-1.4.1p1-plfs/src/mpi/romio/adio/common/ad_opencoll.c	2012-05-23 11:30:04.257510000 -0600
+@@ -80,7 +80,7 @@
+    in fd, so that get_amode returns the right answer. */
+ 
+     orig_amode_wronly = access_mode;
+-    if (access_mode & ADIO_WRONLY) {
++    if (access_mode & ADIO_WRONLY && fd->file_system != ADIO_PLFS) {
+ 	access_mode = access_mode ^ ADIO_WRONLY;
+ 	access_mode = access_mode | ADIO_RDWR;
+     }
 diff -Naur mpich2-1.4.1p1/src/mpi/romio/adio/include/adio.h mpich2-1.4.1p1-plfs/src/mpi/romio/adio/include/adio.h
 --- mpich2-1.4.1p1/src/mpi/romio/adio/include/adio.h	2011-05-12 08:41:57.000000000 -0600
 +++ mpich2-1.4.1p1-plfs/src/mpi/romio/adio/include/adio.h	2012-05-23 09:42:45.083774000 -0600

--- a/mpi_adio/patches/openmpi/ompi-1.6.x-plfs-prep.patch
+++ b/mpi_adio/patches/openmpi/ompi-1.6.x-plfs-prep.patch
@@ -123,6 +123,18 @@ diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/adio/common/ad_fstype.c openmpi-1
      if (file_system == ADIO_HFS) {
  #ifndef ROMIO_HFS
  	*error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/adio/common/ad_opencoll.c openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/common/ad_opencoll.c
+--- openmpi-1.6/ompi/mca/io/romio/romio/adio/common/ad_opencoll.c	2012-04-03 08:30:22.000000000 -0600
++++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/common/ad_opencoll.c	2012-05-16 11:59:12.594192000 -0600
+@@ -80,7 +80,7 @@
+    in fd, so that get_amode returns the right answer. */
+ 
+     orig_amode_wronly = access_mode;
+-    if (access_mode & ADIO_WRONLY) {
++    if (access_mode & ADIO_WRONLY && fd->file_system != ADIO_PLFS) {
+ 	access_mode = access_mode ^ ADIO_WRONLY;
+ 	access_mode = access_mode | ADIO_RDWR;
+     }
 diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/adio/include/adio.h openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/include/adio.h
 --- openmpi-1.6/ompi/mca/io/romio/romio/adio/include/adio.h	2012-04-03 08:30:21.000000000 -0600
 +++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/include/adio.h	2012-05-16 12:08:40.191472000 -0600


### PR DESCRIPTION
It turns out that turning off data-sieving works, but doesn't prevent
romio from opening a file read-write when calling on ADIOI_GEN_OpenColl.
We still need to patch, but we only need to patch the file that has
ADIOI_GEN_OpenColl, which is ad_opencoll.c.
