### PR TITLE
C directives around weak symbols so that only Cray uses them.

### DIFF
--- a/mpi_adio/ad_plfs/ad_plfs.c
+++ b/mpi_adio/ad_plfs/ad_plfs.c
@@ -123,6 +123,7 @@ void check_stream(int size,int rank)
     }
 }
 
+#ifdef ROMIO_CRAY
 /* --BEGIN CRAY ADDITION-- */
 
 /*
@@ -326,3 +327,4 @@ plfs_filetype plfs_get_filetype(const char *path)
 }
 
 /* --END CRAY ADDITION-- */
+#endif


### PR DESCRIPTION
With directives around the weak symbols, they are turned off by default.
Normal linking needs to be done when building MPI and leaving out the
weak symbols when dynamically linking will ensure that the right
versions of the functions are found.
