### PR TITLE
plfs: defer data/index dropping creation

### DIFF
--- a/man/man5/plfsrc.5in
+++ b/man/man5/plfsrc.5in
@@ -229,6 +229,18 @@ Indeed it is an error to share a backend in multiple backends.
 .RE
 
 .B
+lazy_droppings
+.RS
+Plfs container tries to defer the creation of data droppings and index droppings
+until the first write/truncate. Therefore if a file is opened and closed without
+any writes in between, plfs doesn't need to create empty data/index droppings.
+
+To disable the behavior, set lazy_droppings = 0.
+
+Optional. The default is 1.
+.RE
+
+.B
 mlog_defmask
 .RS
 The default logging level.  This is used to control how much logging

--- a/src/Container.cpp
+++ b/src/Container.cpp
@@ -19,6 +19,7 @@ using namespace std;
 #include "Util.h"
 #include "ThreadPool.h"
 #include "mlog_oss.h"
+#include "container_internals.h"
 
 #define BLKSIZE 512
 
@@ -1753,6 +1754,12 @@ Container::makeDropping(const string& path, struct plfs_backend *b)
     int ret = makeDroppingReal( path, b, DROPPING_MODE );
     umask(save_umask);
     return ret;
+}
+int
+Container::prepareWriter(WriteFile *wf, pid_t pid, mode_t mode,
+                         const string& logical)
+{
+    return container_prepare_writer(wf, pid, mode, logical);
 }
 // returns 0 or -err
 int

--- a/src/Container.h
+++ b/src/Container.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <deque>
 
+#include "WriteFile.h"
 
 using namespace std;
 
@@ -113,6 +114,8 @@ class Container
         static mode_t subdirMode(  mode_t );
 
 
+        static int prepareWriter(WriteFile *wf, pid_t pid, mode_t mode,
+                                 const string& logical);
         static int makeHostDir(const string& path, struct plfs_backend *b,
                                const string& host,
                                mode_t mode, parentStatus);

--- a/src/WriteFile.cpp
+++ b/src/WriteFile.cpp
@@ -17,8 +17,8 @@ using namespace std;
 // shadow or canonical container (i.e. not relying on symlinks)
 // anyway, this should all happen above WriteFile and be transparent to
 // WriteFile.  This comment is for educational purposes only.
-WriteFile::WriteFile(string path, string newhostname,
-                     mode_t newmode, size_t buffer_mbs,
+WriteFile::WriteFile(string path, string newhostname, mode_t newmode,
+                     size_t buffer_mbs, int pid, string logical,
                      struct plfs_backend *backend) : Metadata::Metadata()
 {
     this->container_path    = path;
@@ -32,6 +32,8 @@ WriteFile::WriteFile(string path, string newhostname,
     this->write_count       = 0;
     this->index_buffer_mbs  = buffer_mbs;
     this->max_writers       = 0;
+    this->open_pid          = pid;
+    this->logical_path      = logical;
     pthread_mutex_init( &data_mux, NULL );
     pthread_mutex_init( &index_mux, NULL );
 }
@@ -77,11 +79,20 @@ WriteFile::~WriteFile()
 int WriteFile::sync()
 {
     int ret = 0;
+
+    // No writers yet? nothing to sync.
+    if ( fhs.empty() ) {
+        return ret;
+    }
+
     // iterate through and sync all open fds
     Util::MutexLock( &data_mux, __FUNCTION__ );
     map<pid_t, OpenFh >::iterator pids_itr;
     for( pids_itr = fhs.begin(); pids_itr != fhs.end() && ret==0; pids_itr++ ) {
         ret = pids_itr->second.fh->Fsync();
+        if ( ret != 0 ) {
+            break;
+        }
     }
     Util::MutexUnlock( &data_mux, __FUNCTION__ );
 
@@ -128,34 +139,53 @@ int WriteFile::sync( pid_t pid )
 }
 
 
-// returns -err or number of writers
-int WriteFile::addWriter( pid_t pid, bool child )
+// Parameters:
+// @pid, who wants to write
+// @for_open, this is called in open path and need to increase open ref count
+// @defer_open, if true, do not really open droppings if not opened yet
+// @writers, returns number of concurrent writers
+//
+// Returns 0 if ofh already exists or if user wants to open and open succeeds.
+// If lazy_open, always return 0.
+//
+// The life cycle of an ofh is:
+// At open, all possible writers take a reference on ofh, which may not be
+// created yet. Whoever first writes creates the ofh and put it in fhs map.
+// During close, the last closer of the ofh gets the chance to destroy the ofh.
+int WriteFile::addWriter( pid_t pid, bool for_open, bool defer_open, int& writers )
 {
     int ret = 0;
-    Util::MutexLock(   &data_mux, __FUNCTION__ );
+    Util::MutexLock( &data_mux, __FUNCTION__ );
     struct OpenFh *ofh = getFh( pid );
-    if (ofh != NULL) {
-        ofh->writers++;
-    } else {
-        /* note: this uses subdirback from object to open */
+    if ( ofh == NULL && !defer_open ) {
+        // note: this uses subdirback from object to open
         IOSHandle *fh;
-        fh = openDataFile( subdir_path, hostname, pid, DROPPING_MODE, ret);
+        fh = openDataFile( subdir_path, hostname, pid, DROPPING_MODE, ret );
         if ( fh != NULL ) {
             struct OpenFh xofh;
-            xofh.writers = 1;
             xofh.fh = fh;
             fhs[pid] = xofh;
         } // else, ret was already set
     }
-    int writers = incrementOpens(0);
-    if ( ret == 0 && ! child ) {
+
+    if ( ret == 0 && for_open ) {
+        // We now decouple ofh reference counting from its instantiation. Any
+        // write-opener now takes a ref count (saved in the fhs_writes map) and
+        // ofh is created by the first real writer in its first write/truncate
+        // calls (and saved in the fhs map). Once created, an ofh is ref-counted
+        // by fhs_writers map and shared by all write-openers.
+        // For new entry, std::map initilizes to 0
+        fhs_writers[pid]++;
+        max_writers++;
         writers = incrementOpens(1);
+    } else {
+        writers = incrementOpens(0);
     }
-    max_writers++;
+
     mlog(WF_DAPI, "%s (%d) on %s now has %d writers",
          __FUNCTION__, pid, container_path.c_str(), writers );
     Util::MutexUnlock( &data_mux, __FUNCTION__ );
-    return ( ret == 0 ? writers : ret );
+    return ret;
 }
 
 size_t WriteFile::numWriters( )
@@ -165,9 +195,12 @@ size_t WriteFile::numWriters( )
     if ( paranoid_about_reference_counting ) {
         int check = 0;
         Util::MutexLock(   &data_mux, __FUNCTION__ );
-        map<pid_t, OpenFh >::iterator pids_itr;
-        for( pids_itr = fhs.begin(); pids_itr != fhs.end(); pids_itr++ ) {
-            check += pids_itr->second.writers;
+        map<pid_t, int >::iterator pids_itr;
+        for( pids_itr = fhs_writers.begin();
+             pids_itr != fhs_writers.end();
+             pids_itr++ )
+        {
+            check += pids_itr->second;
         }
         if ( writers != check ) {
             mlog(WF_DRARE, "%s %d not equal %d", __FUNCTION__,
@@ -246,40 +279,64 @@ int
 WriteFile::removeWriter( pid_t pid )
 {
     int ret = 0;
-    Util::MutexLock(   &data_mux , __FUNCTION__);
-    struct OpenFh *ofh = getFh( pid );
+
+    Util::MutexLock( &data_mux, __FUNCTION__ );
     int writers = incrementOpens(-1);
-    if ( ofh == NULL ) {
-        // if we can't find it, we still decrement the writers count
-        // this is strange but sometimes fuse does weird things w/ pids
-        // if the writers goes zero, when this struct is freed, everything
-        // gets cleaned up
-        mlog(WF_CRIT, "%s can't find pid %d", __FUNCTION__, pid );
-        assert( 0 );
-    } else {
-        ofh->writers--;
-        if ( ofh->writers <= 0 ) {
+    // Only the last closer of an ofh gets the chance to destroy it
+    if ( --fhs_writers[pid] <= 0 ) {
+        struct OpenFh *ofh = getFh( pid );
+        if ( ofh != NULL) {
             ret = closeFh( ofh->fh );
             fhs.erase( pid );
         }
+        fhs_writers.erase( pid );
     }
+    Util::MutexUnlock( &data_mux, __FUNCTION__ );
+
     mlog(WF_DAPI, "%s (%d) on %s now has %d writers: %d",
          __FUNCTION__, pid, container_path.c_str(), writers, ret );
-    Util::MutexUnlock( &data_mux, __FUNCTION__ );
     return ( ret == 0 ? writers : ret );
 }
 
+// return 0 on success. -err on error
 int
 WriteFile::extend( off_t offset )
 {
-    // make a fake write
-    if ( fhs.begin() == fhs.end() ) {
-        return -ENOENT;
+    // make a fake write. We may be the first writer.
+    int ret;
+    ret = prepareForWrite();
+    if ( ret == 0 ) {
+        index->addWrite( offset, 0, open_pid, createtime, createtime );
+        addWrite( offset, 0 );   // maintain metadata
     }
-    pid_t p = fhs.begin()->first;
-    index->addWrite( offset, 0, p, createtime, createtime );
-    addWrite( offset, 0 );   // maintain metadata
-    return 0;
+
+    return ret;
+}
+
+// return 0 on success. -err on error
+int
+WriteFile::prepareForWrite( pid_t pid )
+{
+    int ret = 0;
+    OpenFh *ofh;
+
+    ofh = getFh( pid );
+    if ( ofh == NULL ) {
+        // After changing to avoid creating empty data dropping and
+        // index files in open, we defer the creation until first
+        // write, which is here.
+        ret = Container::prepareWriter( this, pid, mode, logical_path );
+    }
+
+    // we also defer creating index dropping. so index may be NULL.
+    if ( ret >= 0 && index == NULL ) {
+        ret = openIndex( pid );
+        if ( ret < 0 ) {
+            mlog( WF_ERR, "%s open index failed", __FUNCTION__ );
+        }
+    }
+
+    return (ret >= 0) ? 0 : ret;
 }
 
 // we are currently doing synchronous index writing.
@@ -294,20 +351,10 @@ WriteFile::write(const char *buf, size_t size, off_t offset, pid_t pid)
 {
     int ret = 0;
     ssize_t written;
-    OpenFh *ofh = getFh( pid );
-    if ( ofh == NULL ) {
-        // we used to return -ENOENT here but we can get here legitimately
-        // when a parent opens a file and a child writes to it.
-        // so when we get here, we need to add a child datafile
-        ret = addWriter( pid, true );
-        if ( ret > 0 ) {
-            // however, this screws up the reference count
-            // it looks like a new writer but it's multiple writers
-            // sharing an fd ...
-            ofh = getFh( pid );
-        }
-    }
-    if ( ofh != NULL && ret >= 0 ) {
+
+    ret = prepareForWrite( pid );
+    if ( ret == 0 ) {
+        OpenFh *ofh = getFh( pid );
         IOSHandle *wfh = ofh->fh;
         // write the data file
         double begin, end;
@@ -342,23 +389,32 @@ WriteFile::write(const char *buf, size_t size, off_t offset, pid_t pid)
 
 // this assumes that the hostdir exists and is full valid path
 // returns 0 or -err
-int WriteFile::openIndex( pid_t pid ) {
+int WriteFile::openIndex( pid_t pid )
+{
     int ret = 0;
+
+    Util::MutexLock( &index_mux, __FUNCTION__ );
+    if ( index != NULL ) {
+        // someone created index for us... That's OK.
+        Util::MutexUnlock( &index_mux, __FUNCTION__ );
+        return ret;
+    }
+
     string index_path;
     /* note: this uses subdirback from obj to open */
     IOSHandle *fh = openIndexFile(subdir_path, hostname, pid, DROPPING_MODE,
                                   &index_path, ret);
     if ( fh != NULL ) {
-        Util::MutexLock(&index_mux , __FUNCTION__);
         //XXXCDC:iostore need to pass the backend down into index?
         index = new Index(container_path, subdirback, fh);
-        Util::MutexUnlock(&index_mux, __FUNCTION__);
         mlog(WF_DAPI, "In open Index path is %s",index_path.c_str());
-        index->index_path=index_path;
-        if(index_buffer_mbs) {
+        index->index_path = index_path;
+        if ( index_buffer_mbs ) {
             index->startBuffering();
         }
     }
+    Util::MutexUnlock( &index_mux, __FUNCTION__ );
+
     return ret;
 }
 
@@ -367,6 +423,12 @@ int WriteFile::closeIndex( )
     IOSHandle *closefh;
     struct plfs_backend *ib;
     int ret = 0;
+
+    // index is not opened
+    if ( index == NULL ) {
+        return ret;
+    }
+
     Util::MutexLock(   &index_mux , __FUNCTION__);
     ret = index->flush();
     closefh = index->getFh(&ib);
@@ -400,7 +462,16 @@ int WriteFile::Close()
 // returns 0 or -err
 int WriteFile::truncate( off_t offset )
 {
+    int ret = 0;
     Metadata::truncate( offset );
+    // we may be the first writer...
+    if ( index == NULL ) {
+        OpenFh *ofh;
+        ret = prepareForWrite();
+        if ( ret < 0 ) {
+            return ret;
+        }
+    }
     index->truncateHostIndex( offset );
     return 0;
 }

--- a/src/container_internals.cpp
+++ b/src/container_internals.cpp
@@ -184,12 +184,11 @@ container_create( const char *logical, mode_t mode, int flags, pid_t pid )
 // into the canonical_container
 // returns number of current writers sharing the WriteFile * or -err
 int
-addWriter(WriteFile *wf, pid_t pid, const char *path, mode_t mode,
-          string logical )
+addPrepareWriter( WriteFile *wf, pid_t pid, mode_t mode,
+                  const string& logical, bool for_open, bool defer_open )
 {
-    int ret = -ENOENT;  // be pessimistic
-    int writers = 0;
-    struct plfs_backend *newback;
+    int ret, writers;
+
     // might have to loop 3 times
     // first discover that the subdir doesn't exist
     // try to create it and try again
@@ -198,14 +197,18 @@ addWriter(WriteFile *wf, pid_t pid, const char *path, mode_t mode,
     // but that might fail if our sibling hasn't created where it resolves yet
     // so help our sibling create it, and then finally try the third time.
     for( int attempts = 0; attempts < 2; attempts++ ) {
-        // ok, the WriteFile *wf has a container path in it which is
-        // path to canonical.  It attempts to open a file in a subdir
+        // for defer_open , wf->addWriter() only increases writer ref counts,
+        // since it doesn't actually do anything until it gets asked to write
+        // for the first time at which point it actually then attempts to
+        // O_CREAT its required data and index logs
+        // for !defer_open, the WriteFile *wf has a container path in it
+        // which is path to canonical.  It attempts to open a file in a subdir
         // at that path.  If it fails, it should be bec there is no
         // subdir in the canonical. [If it fails for any other reason, something
         // is badly broken somewhere.]
         // When it fails, create the hostdir.  It might be a metalink in
         // which case change the container path in the WriteFile to shadow path
-        writers = ret = wf->addWriter( pid, false );
+        ret = wf->addWriter( pid, for_open, defer_open, writers );
         if ( ret != -ENOENT ) {
             break;    // everything except ENOENT leaves
         }
@@ -224,6 +227,7 @@ addWriter(WriteFile *wf, pid_t pid, const char *path, mode_t mode,
         if (ret!=0) {
             PLFS_EXIT(ret);
         }
+        struct plfs_backend *newback;
         ret=Container::makeHostDir(paths, mode, PARENT_ABSENT,
                                    physical_hostdir, &newback, use_metalink);
         if ( ret==0 ) {
@@ -246,6 +250,20 @@ addWriter(WriteFile *wf, pid_t pid, const char *path, mode_t mode,
         ret = writers;
     }
     PLFS_EXIT(ret);
+}
+
+int
+container_prepare_writer( WriteFile *wf, pid_t pid, mode_t mode,
+                          const string& logical )
+{
+    return addPrepareWriter( wf, pid, mode, logical, false, false );
+}
+
+int
+openAddWriter( WriteFile *wf, pid_t pid, mode_t mode, string logical,
+               bool defer_open )
+{
+    return addPrepareWriter( wf, pid, mode, logical, true, defer_open );
 }
 
 int
@@ -480,6 +498,9 @@ container_rename_open_file(Container_OpenFile *of, const char *logical,
 {
     PLFS_ENTER;
     of->setPath(path.c_str(),b);
+    WriteFile *wf = of->getWritefile();
+    if ( wf )
+        wf->setLogical(logical);
     PLFS_EXIT(ret);
 }
 
@@ -1373,19 +1394,20 @@ container_open(Container_OpenFile **pfd,const char *logical,int flags,
                 indx_sz = get_plfs_conf()->buffer_mbs;
             }
             /*
-             * wf starts with the canonical backend.   the addWriter()
+             * wf starts with the canonical backend.   the openAddWriter()
              * call below may change it (e.g. to a shadow backend).
              */
             wf = new WriteFile(path, Util::hostname(), mode,
-                               indx_sz, expansion_info.backend);
+                               indx_sz, pid, logical, expansion_info.backend);
             new_writefile = true;
         }
-        ret = addWriter(wf, pid, path.c_str(), mode,logical);
+        bool defer_open = get_plfs_conf()->lazy_droppings;
+        ret = openAddWriter(wf, pid, mode, logical, defer_open );
         mlog(INT_DCOMMON, "%s added writer: %d", __FUNCTION__, ret );
         if ( ret > 0 ) {
             ret = 0;    // add writer returns # of current writers
         }
-        if ( ret == 0 && new_writefile ) {
+        if ( ret == 0 && new_writefile && !defer_open ) {
             ret = wf->openIndex( pid );
         }
         if ( ret != 0 && wf ) {

--- a/src/container_internals.h
+++ b/src/container_internals.h
@@ -60,5 +60,7 @@ int container_utime( const char *path, struct utimbuf *ut );
 ssize_t container_write( Container_OpenFile *, const char *, size_t, off_t,
                          pid_t );
 
+int container_prepare_writer( WriteFile *, pid_t, mode_t, const string& );
+
 int container_flatten_index(Container_OpenFile *fd, const char *logical);
 #endif

--- a/src/plfs_private.cpp
+++ b/src/plfs_private.cpp
@@ -398,6 +398,9 @@ plfs_dump_config(int check_dirs, int make_dir)
     if (pconf->test_metalink) {
         cout << "Test metalink: TRUE" << endl;
     }
+    if (pconf->lazy_droppings) {
+        cout << "Lazy droppings: TRUE" << endl;
+    }
     map<string,PlfsMount *>::iterator itr;
     for(itr=pconf->mnt_pts.begin(); itr!=pconf->mnt_pts.end(); itr++) {
         PlfsMount *pmnt = itr->second;
@@ -1100,6 +1103,7 @@ set_default_confs(PlfsConf *pconf)
     pconf->global_sum_io.prefix = NULL;
     pconf->global_sum_io.store = NULL;
     pconf->test_metalink = 0;
+    pconf->lazy_droppings = 1;
     /* default mlog settings */
     pconf->mlog_flags = MLOG_LOGPID;
     pconf->mlog_defmask = MLOG_WARN;
@@ -1235,6 +1239,8 @@ parse_conf_keyval(PlfsConf *pconf, PlfsMount **pmntp, char *file,
                     " or if performance is important, pls edit %s to"
                     " remove the test_metalink directive\n", file);
         }
+    } else if (strcmp(key,"lazy_droppings")==0) {
+        pconf->lazy_droppings = atoi(value)==0 ? 0 : 1;
     } else if (strcmp(key,"num_hostdirs")==0) {
         pconf->num_hostdirs = atoi(value);
         if (pconf->num_hostdirs <= 0) {

--- a/src/plfs_private.h
+++ b/src/plfs_private.h
@@ -125,6 +125,7 @@ typedef struct {
     bool direct_io; // a flag FUSE needs.  Sorry ADIO and API for the wasted bit
     bool test_metalink; // for developers only
     bool lazy_stat;
+    bool lazy_droppings; // defer index/data droppings creation until first write
     string *err_msg;
 
     char *global_summary_dir;


### PR DESCRIPTION
Please pull deferring empty dropping creation patch to get following optimization. The code is based on the head of small_file branch.

In open for write, don't create empty data and index files.
Only create them in the first write. Hostdir creation is also
deferred to the first write when possible.

A configurable is added in plfsrc to control the logic.
Add "lazy_droppings 0" to plfsrc to disable the feature.
