### PR TITLE
There was a bug where the mlog_oss was always setting noLog to false.

### DIFF
--- a/fuse/plfs_fuse.cpp
+++ b/fuse/plfs_fuse.cpp
@@ -3,6 +3,7 @@
 #include "IOStore.h"
 #include "LogMessage.h"
 #include "COPYRIGHT.h"
+#include "mlog_oss.h"
 
 #include <errno.h>
 #include <string>
@@ -156,7 +157,7 @@ class generic_exception: public exception
 #define DEBUG_MUTEX_OFF
 #endif
 
-#define FUSE_PLFS_ENTER vector<gid_t> orig_groups;                                 \
+#define FUSE_PLFS_ENTER vector<gid_t> orig_groups;                            \
                    ostringstream funct_id;                                    \
                    LogMessage lm, lm2;                                        \
                    DEBUG_MUTEX_ON;                                            \
@@ -166,7 +167,7 @@ class generic_exception: public exception
                    START_TIMES;                                               \
                    START_MESSAGE;                                             \
                    lm << funct_id.str();                              \
-                   mlog(FUSE_DBG,"%s BEGIN", lm.str().c_str());                 \
+                   mlog(FUSE_DBG,"%s BEGIN", lm.str().c_str());               \
                    lm << endl;                              \
                    lm.flush();                                                \
                    SAVE_IDS;                                                  \
@@ -187,7 +188,7 @@ class generic_exception: public exception
                    END_TIMES;                                           \
                    END_MESSAGE;                                         \
                    lm2 << funct_id.str();\
-                   mlog(FUSE_DBG,"%s END", lm2.str().c_str());                  \
+                   mlog(FUSE_DBG,"%s END", lm2.str().c_str());          \
                    lm2 << endl;                                         \
                    lm2.flush();                                         \
                    DEBUG_MUTEX_OFF;                                     \
@@ -199,10 +200,10 @@ class generic_exception: public exception
                        Plfs_fd *of = NULL;                                   \
                        if ( openfile ) {                                     \
                            of = (Plfs_fd *)openfile->pfd;                    \
-                           ostringstream oss;                                \
+                           mss::mlog_oss oss(FUSE_DBG);                      \
                            oss << __FUNCTION__ << " got OpenFile for " <<    \
                                strPath.c_str() << " (" << of << ")" ;   \
-                           mlog(FUSE_DCOMMON, "%s", oss.str().c_str() ); \
+                           oss.commit();                                \
                        }
 
 
@@ -997,10 +998,10 @@ int Plfs::f_release( const char *path, struct fuse_file_info *fi )
 // the fd_mutex should be held when calling this
 int Plfs::addOpenFile( string expanded, pid_t pid, Plfs_fd *pfd)
 {
-    ostringstream oss;
+    mss::mlog_oss oss;
     oss << __FUNCTION__ << " adding OpenFile for " <<
         expanded << " (" << pfd << ") pid " << pid;
-    mlog(FUSE_DCOMMON, "%s", oss.str().c_str() );
+    oss.commit();
     self->open_files[expanded] = pfd;
     //mlog(FUSE_DCOMMON, "Current open files: %s",
     //openFilesToString(false).c_str());
@@ -1013,12 +1014,12 @@ int Plfs::addOpenFile( string expanded, pid_t pid, Plfs_fd *pfd)
 // it has already been removed
 int Plfs::removeOpenFile(string expanded, pid_t pid, Plfs_fd *pfd)
 {
-    ostringstream oss;
+    mss::mlog_oss oss;
     int erased = 0;
     erased = self->open_files.erase( expanded );
     oss << __FUNCTION__ << " removed " << erased << " OpenFile for " <<
         expanded << " (" << pfd << ") pid " << pid;
-    mlog(FUSE_DCOMMON, "%s",oss.str().c_str());
+    oss.commit();
     //mlog(FUSE_DCOMMON, "Current open files: %s",
     //     openFilesToString(false).c_str());
     return erased;
@@ -1035,11 +1036,11 @@ Plfs_fd *Plfs::findOpenFile( string expanded )
         mlog(FUSE_DCOMMON, "No OpenFile found for %s", expanded.c_str() );
         pfd = NULL;
     } else {
-        ostringstream oss;
+        mss::mlog_oss oss;
         pfd = itr->second;
         oss << __FUNCTION__ << " OpenFile " << pfd << " found for " <<
             expanded.c_str();
-        mlog(FUSE_DCOMMON, "%s", oss.str().c_str() );
+        oss.commit();
     }
     return pfd;
 }

--- a/src/LogicalFS/Container/Container.cpp
+++ b/src/LogicalFS/Container/Container.cpp
@@ -1477,7 +1477,7 @@ Container::getattr( const string& path, struct plfs_backend *canback,
         oss  << "Pulled meta " << last_offset << " " << total_bytes
              << ", " << time.tv_sec << "." << time.tv_nsec
              << " on host " << host;
-        mlog(CON_DCOMMON, "%s", oss.str().c_str() );
+        oss.commit();
         // oh, let's get rewrite correct.  if someone writes
         // a file, and they close it and then later they
         // open it again and write some more then we'll
@@ -1537,7 +1537,7 @@ Container::getattr( const string& path, struct plfs_backend *canback,
     oss  << "Examined " << chunks << " droppings:"
          << path << " total size " << stbuf->st_size <<  ", usage "
          << stbuf->st_blocks << " at " << stbuf->st_blksize;
-    mlog(CON_DCOMMON, "%s", oss.str().c_str() );
+    oss.commit();
     return ret;
 }
 

--- a/src/LogicalFS/Container/Index/Index.cpp
+++ b/src/LogicalFS/Container/Index/Index.cpp
@@ -378,7 +378,7 @@ Index::~Index()
     os << __FUNCTION__ << ": " << this
        << " removing index on " << physical_path << ", "
        << chunk_map.size() << " chunks";
-    mlog(IDX_DAPI, "%s", os.str().c_str() );
+    os.commit();
     mlog(IDX_DCOMMON, "There are %lu chunks to close fds for",
          (unsigned long)chunk_map.size());
     /*
@@ -583,7 +583,7 @@ int Index::readIndex( string hostindex, struct plfs_backend *hback )
     mss::mlog_oss os(IDX_DAPI);
     os << __FUNCTION__ << ": " << this << " reading index on " <<
        physical_path;
-    mlog(IDX_DAPI, "%s", os.str().c_str() );
+    os.commit();
 
     rv = mapIndex(&maddr, hostindex, &rfh, &length, hback);
 
@@ -995,7 +995,7 @@ int Index::handleOverlap(ContainerEntry& incoming,
     for(cur=winners.begin(); cur!=winners.end(); cur++) {
         oss << cur->second;
     }
-    mlog(IDX_DCOMMON, "%s",oss.str().c_str());
+    oss.commit();
     // I've seen weird cases where when a file is continuously overwritten
     // slightly (like config.log), that it makes a huge mess of small little
     // chunks.  It'd be nice to compress winners before inserting into global
@@ -1038,7 +1038,7 @@ Index::insertGlobal( ContainerEntry *g_entry )
     if ( ret.second == false ) {
         ioss << "overlap1" <<endl<< *g_entry <<endl << 
                 ret.first->second << endl;
-        mlog(IDX_DCOMMON, "%s", ioss.str().c_str() );
+        ioss.commit();
         overlap  = true;
     }
     // also, need to check against prev and next for overlap
@@ -1050,20 +1050,20 @@ Index::insertGlobal( ContainerEntry *g_entry )
     if ( next != global_index.end() && g_entry->overlap( next->second ) ) {
         mss::mlog_oss oss(IDX_DCOMMON);
         oss << "overlap2 " << endl << *g_entry << endl <<next->second;
-        mlog(IDX_DCOMMON, "%s", oss.str().c_str() );
+        oss.commit();
         overlap = true;
     }
     if (ret.first!=global_index.begin() && prev->second.overlap(*g_entry) ) {
         mss::mlog_oss oss(IDX_DCOMMON);
         oss << "overlap3 " << endl << *g_entry << endl <<prev->second;
-        mlog(IDX_DCOMMON, "%s", oss.str().c_str() );
+        oss.commit();
         overlap = true;
     }
     if ( overlap ) {
         mss::mlog_oss oss(IDX_DCOMMON);
         oss << __FUNCTION__ << " of " << physical_path << " trying to insert "
             << "overlap at " << g_entry->logical_offset;
-        mlog(IDX_DCOMMON, "%s", oss.str().c_str() );
+        oss.commit();
         //handleOverlap with entry length 0 is broken
         //not exactly sure why
         if (g_entry->length != 0){
@@ -1074,7 +1074,7 @@ Index::insertGlobal( ContainerEntry *g_entry )
         if (ret.first!=global_index.begin() && g_entry->follows(prev->second)) {
             ioss << "Merging index for " << *g_entry << " and " << prev->second
                 << endl;
-            mlog(IDX_DCOMMON, "%s", ioss.str().c_str());
+            ioss.commit();
             prev->second.length += g_entry->length;
             global_index.erase( ret.first );
         }
@@ -1201,7 +1201,7 @@ int Index::globalLookup( IOSHandle **xfh, off_t *chunk_off, size_t *chunk_len,
 {
     mss::mlog_oss os(IDX_DAPI);
     os << __FUNCTION__ << ": " << this << " using index.";
-    mlog(IDX_DAPI, "%s", os.str().c_str() );
+    os.commit();
     *hole = false;
     *chunkid = (pid_t)-1;
     //mlog(IDX_DCOMMON, "Look up %ld in %s",
@@ -1264,7 +1264,7 @@ int Index::globalLookup( IOSHandle **xfh, off_t *chunk_off, size_t *chunk_len,
     if ( logical < entry.logical_offset ) {
         mss::mlog_oss oss(IDX_DCOMMON);
         oss << "FOUND(4): " << logical << " is in a hole";
-        mlog(IDX_DCOMMON, "%s", oss.str().c_str() );
+        oss.commit();
         off_t remaining_hole_size = entry.logical_offset - logical;
         *xfh = NULL;
         *chunk_len = remaining_hole_size;

--- a/src/LogicalFS/Container/container_internals.cpp
+++ b/src/LogicalFS/Container/container_internals.cpp
@@ -1788,7 +1788,7 @@ container_getattr(Container_OpenFile *of, const char *logical,
     oss << __FUNCTION__ << " of " << path << "("
         << (of == NULL ? "closed" : "open")
         << ") size is " << stbuf->st_size;
-    mlog(PLFS_DAPI, "%s", oss.str().c_str());
+    oss.commit();
     PLFS_EXIT(ret);
 }
 
@@ -2035,7 +2035,7 @@ plfs_reference_count( Container_OpenFile *pfd )
         mss::mlog_oss oss(INT_DRARE);
         oss << __FUNCTION__ << " not equal counts: " << ref_count
             << " != " << pfd->incrementOpens(0) << endl;
-        mlog(INT_DRARE, "%s", oss.str().c_str() );
+        oss.commit();
         assert( ref_count == pfd->incrementOpens(0) );
     }
     return ref_count;
@@ -2122,7 +2122,7 @@ container_close( Container_OpenFile *pfd, pid_t pid, uid_t uid, int open_flags,
     if ( ret == 0 && ref_count == 0 ) {
         mss::mlog_oss oss(PLFS_DCOMMON);
         oss << __FUNCTION__ << " removing OpenFile " << pfd;
-        mlog(PLFS_DCOMMON, "%s", oss.str().c_str() );
+        oss.commit();
         delete pfd;
         pfd = NULL;
     }

--- a/src/Mlog/mlog_oss.cpp
+++ b/src/Mlog/mlog_oss.cpp
@@ -6,10 +6,21 @@ mss::mlog_oss::mlog_oss() {
 
 mss::mlog_oss::mlog_oss(int lvl) {
     if (MLOG_NEVERLOG == 0 &&
-            mlog_filter(level)) {
+            mlog_filter(lvl)) {
         noLog = false;
+        this->level = lvl;
     } else {
         noLog = true;
+    }
+}
+
+bool
+mss::mlog_oss::commit() {
+    if (!noLog) {
+        mlog(level, "%s", oss.str().c_str());
+        return true;
+    } else {
+        return false;
     }
 }
 

--- a/src/Mlog/mlog_oss.h
+++ b/src/Mlog/mlog_oss.h
@@ -13,10 +13,12 @@ namespace mss {
             int level;
             bool noLog;
 
+
         public:
             mlog_oss();
             mlog_oss(int lvl);
             bool getNoLog();
+            bool commit();
             
             template <typename T>
             void insert(T xin) {

--- a/src/PLFSIndex.cpp
+++ b/src/PLFSIndex.cpp
@@ -85,7 +85,7 @@ find_read_tasks(PLFSIndex *index, list<ReadTask> *tasks, size_t size,
                 }
             }
             // remember this task
-            mlog(INT_DCOMMON, "%s", oss.str().c_str() );
+            oss.commit();
             tasks->push_back(task);
         }
         // when chunk_length is 0, that means EOF
@@ -148,7 +148,7 @@ perform_read_task( ReadTask *task, PLFSIndex *index )
     mss::mlog_oss oss(INT_DCOMMON);
     oss << "\t READ TASK: offset " << task->chunk_offset << " len "
         << task->length << " fh " << task->fh << ": ret " << ret;
-    mlog(INT_DCOMMON, "%s", oss.str().c_str() );
+    oss.commit();
     PLFS_EXIT(ret);
 }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -52,15 +52,14 @@ using namespace std;
 #ifndef UTIL_COLLECT_TIMES
 off_t total_ops = 0;
 #define ENTER_UTIL int ret = 0; total_ops++;
-#define ENTER_IO   ssize_t ret = 0;
+#define ENTER_IO   ssize_t ret = 0; total_ops++;
 #define EXIT_IO    return ret;
 #define EXIT_UTIL  return ret;
 #define ENTER_MUX  ENTER_UTIL;
 #define ENTER_PATH ENTER_UTIL;
 #else
-#define DEBUG_ENTER /* mlog(UT_DAPI, "Enter %s", __FUNCTION__ );*/
+#define DEBUG_ENTER mss::mlog_oss oss(UT_DAPI);
 #define DEBUG_EXIT  LogMessage lm1;                             \
-                        mss::mlog_oss oss(UT_DAPI);             \
                         oss << "Util::" << setw(13) << __FUNCTION__; \
                         if (path) oss << " on " << path << " ";     \
                         oss << setw(7) << " ret=" << setprecision(0) << ret    \
@@ -68,7 +67,7 @@ off_t total_ops = 0;
                             << end-begin << endl; \
                         lm1 << oss.str();                           \
                         lm1.flush();                                \
-                        mlog(UT_DAPI, "%s", oss.str().c_str());
+                        oss.commit();
 
 #define ENTER_MUX   LogMessage lm2;                             \
                         lm2 << "Util::" << setw(13) << __FUNCTION__ \
@@ -333,10 +332,10 @@ int Util::MutexLock(  pthread_mutex_t *mux , const char *where )
     ENTER_MUX;
     mss::mlog_oss os(UT_DAPI), os2(UT_DAPI);
     os << "Locking mutex " << mux << " from " << where;
-    mlog(UT_DAPI, "%s", os.str().c_str() );
+    os.commit();
     pthread_mutex_lock( mux );
     os2 << "Locked mutex " << mux << " from " << where;
-    mlog(UT_DAPI, "%s", os2.str().c_str() );
+    os2.commit();
     EXIT_UTIL;
 }
 
@@ -345,7 +344,7 @@ int Util::MutexUnlock( pthread_mutex_t *mux, const char *where )
     ENTER_MUX;
     mss::mlog_oss os(UT_DAPI);
     os << "Unlocking mutex " << mux << " from " << where;
-    mlog(UT_DAPI, "%s", os.str().c_str() );
+    os.commit();
     pthread_mutex_unlock( mux );
     EXIT_UTIL;
 }

--- a/src/plfs.cpp
+++ b/src/plfs.cpp
@@ -5,6 +5,7 @@
 #include "LogicalFD.h"
 #include "XAttrs.h"
 #include <assert.h>
+#include "mlog_oss.h"
 
 void
 debug_enter(const char *func, string msg)
@@ -319,7 +320,7 @@ plfs_query(Plfs_fd *fd, size_t *writers, size_t *readers,
 ssize_t
 plfs_read(Plfs_fd *fd, char *buf, size_t size, off_t offset)
 {
-    ostringstream oss;
+    mss::mlog_oss oss;
     oss << fd->getPath() << " -> " <<offset << ", " << size;
     debug_enter(__FUNCTION__,oss.str());
     memset(buf, (int)'z', size);
@@ -426,7 +427,7 @@ int
 plfs_rename(const char *from, const char *to)
 {
     int ret = 0;
-    ostringstream oss;
+    mss::mlog_oss oss;
     oss << from << " -> " << to;
     char stripped_from[PATH_MAX];
     stripPrefixPath(from, stripped_from);
@@ -482,7 +483,7 @@ int
 plfs_symlink(const char *from, const char *to)
 {
     int ret = 0;
-    ostringstream oss;
+    mss::mlog_oss oss;
     oss << from << " -> " << to;
 
     char stripped_from[PATH_MAX];
@@ -581,7 +582,7 @@ ssize_t
 plfs_write(Plfs_fd *fd, const char *buf, size_t size,
            off_t offset, pid_t pid)
 {
-    ostringstream oss;
+    mss::mlog_oss oss(PLFS_DAPI);
     oss << fd->getPath() << " -> " <<offset << ", " << size;
     debug_enter(__FUNCTION__,oss.str());
     ssize_t wret = 0;


### PR DESCRIPTION
Therefore it was never actually providing any value.  :)

Also, added an mlog_oss::commit() to remove one unnecessary call
to oss.string().c_string() when the noLog was true.
