### PR TITLE
Cmake now fails if fuse isn't found and DISABLE_FUSE isn't specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,7 @@ configure_file (
 #fuse
 find_package(FUSE)
 if (FUSE_FOUND AND NOT DISABLE_FUSE)
+    message("-- FUSE found")
     #build fuse
     AUX_SOURCE_DIRECTORY(fuse plfs_fuse_dir)
     add_executable (plfs_fuse ${plfs_fuse_dir})
@@ -223,6 +224,8 @@ if (FUSE_FOUND AND NOT DISABLE_FUSE)
     SET_TARGET_PROPERTIES(plfs_fuse PROPERTIES OUTPUT_NAME plfs)
     #set install dir
     INSTALL(TARGETS plfs_fuse DESTINATION sbin)
+elseif (NOT DISABLE_FUSE)
+    message(FATAL_ERROR "FUSE not found and DISABLE_FUSE not specified")
 endif(FUSE_FOUND AND NOT DISABLE_FUSE)
 
 #helper tools


### PR DESCRIPTION
Cmake now fails if fuse isn't found and DISABLE_FUSE isn't specified
