### PR TITLE
Fix a build error with OpenMPI v1.4.3

### DIFF
--- a/mpi_adio/ad_plfs/ad_plfs.h
+++ b/mpi_adio/ad_plfs/ad_plfs.h
@@ -53,7 +53,9 @@ void ADIOI_PLFS_Flush(ADIO_File fd, int *error_code);
 void ADIOI_PLFS_Delete(char *filename, int *error_code);
 void ADIOI_PLFS_Resize(ADIO_File fd, ADIO_Offset size, int *error_code);
 void ADIOI_PLFS_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code);
+#ifndef ROMIO_OPENMPI_14x
 int  ADIOI_PLFS_Feature(ADIO_File fd, int flag);
+#endif
 
 int plfs_protect_all(const char *file, MPI_Comm comm);
 

--- a/mpi_adio/ad_plfs/ad_plfs_features.c
+++ b/mpi_adio/ad_plfs/ad_plfs_features.c
@@ -12,6 +12,7 @@
 #define ADIO_UNLINK_AFTER_CLOSE -100
 #endif
 
+#ifndef ROMIO_OPENMPI_14x
 int ADIOI_PLFS_Feature(ADIO_File fd, int flag)
 {
 	switch(flag) {
@@ -30,4 +31,4 @@ int ADIOI_PLFS_Feature(ADIO_File fd, int flag)
 			break;
 	}
 }
-
+#endif


### PR DESCRIPTION
The function ADIOI_PLFS_Feature() shouldn't be defined when
compiling PLFS with OpenMPI 1.4.x.
