### PR TITLE
Add plfs_flush and plfs_invalidate_cache to manage internal cache

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -22,9 +22,11 @@ SET (SEEALSO3 "${SEEALSO3}, plfs_close(3)")
 SET (SEEALSO3 "${SEEALSO3}, plfs_closedir_c(3)")
 SET (SEEALSO3 "${SEEALSO3}, plfs_create(3)")
 SET (SEEALSO3 "${SEEALSO3}, plfs_flatten_index(3)")
+SET (SEEALSO3 "${SEEALSO3}, plfs_flush_writes(3)")
 SET (SEEALSO3 "${SEEALSO3}, plfs_getattr(3)")
 SET (SEEALSO3 "${SEEALSO3}, plfs_get_filetype(3)")
 SET (SEEALSO3 "${SEEALSO3}, plfs_getxattr(3)")
+SET (SEEALSO3 "${SEEALSO3}, plfs_invalidate_read_cache(3)")
 SET (SEEALSO3 "${SEEALSO3}, plfs_link(3)")
 SET (SEEALSO3 "${SEEALSO3}, plfs_mkdir(3)")
 SET (SEEALSO3 "${SEEALSO3}, plfs_mode(3)")
@@ -105,7 +107,8 @@ foreach (MAN3 plfs is_plfs_path plfs_chown plfs_flatten_index plfs_mode
               plfs_query plfs_trunc plfs_opendir_c plfs_readdir_c plfs_closedir_c
               plfs_access plfs_link plfs_read plfs_unlink plfs_get_filetype
               plfs_readdir plfs_utime plfs_chmod 
-              plfs_mkdir plfs_readlink plfs_statvfs )
+              plfs_mkdir plfs_readlink plfs_statvfs
+              plfs_flush_writes plfs_invalidate_read_cache )
     configure_file( "man3/${MAN3}.3in" "${PLFS_BUILD_DIR}/share/man/man3/${MAN3}.3")
 endforeach(MAN3)
 

--- a/man/man3/plfs_flush_writes.3in
+++ b/man/man3/plfs_flush_writes.3in
@@ -1,0 +1,33 @@
+${COPYRIGHT}
+.TH plfs_flush_writes 3 "${PACKAGE_STRING}" 
+.SH NAME
+plfs_flush_writes
+.SH SYNTAX
+#include <plfs.h>
+.PP
+int plfs_flush_writes( const char *dir );
+
+.SH DESCRIPTION
+Flush all the buffers related to all the regular files in the given
+directory to the backends file systems.
+
+See
+.I plfs_invalidate_read_cache(3)
+for more information.
+
+Currently it is only useful for small file mode(workload 1-n), for
+other modes, it does nothing.
+
+.SH INPUT PARAMETERS
+.TP 1i
+dir
+path to the directory to be flushed.
+
+.SH RETURN VALUES
+0 on success, -errno otherwise.
+
+.SH AUTHORS
+${AUTHORS}
+
+.SH SEE ALSO
+${SEEALSO3}

--- a/man/man3/plfs_invalidate_read_cache.3in
+++ b/man/man3/plfs_invalidate_read_cache.3in
@@ -1,0 +1,44 @@
+${COPYRIGHT}
+.TH plfs_invalidate_read_cache 3 "${PACKAGE_STRING}" 
+.SH NAME
+plfs_invalidate_read_cache
+.SH SYNTAX
+#include <plfs.h>
+.PP
+int plfs_invalidate_read_cache( const char *dir );
+
+.SH DESCRIPTION
+Drop all the cached objects related to the given directory, so that
+following readdir/stat can get the correct info about regular files
+in this directory and open/read can get the latest data of those
+regular files in this directory. By latest, it means the data in
+the backend file system instead of stale memory caches.
+
+Memory cache is critical to performance, but the data read from
+cache might be stale in a distributed environment. In order to
+solve this problem, this function is provided to invalidate the cache,
+so that later operations such as plfs_open() or plfs_read() will
+get the latest version of required information from backend
+file systems.
+
+See
+.I plfs_flush_writes(3)
+about how to make PLFS flush all modifications to the backend file
+systems.
+
+Currently it is only useful for small file mode(workload 1-n), for
+other modes, it does nothing.
+
+.SH INPUT PARAMETERS
+.TP 1i
+dir
+path to the directory whose cached objects will be dropped.
+
+.SH RETURN VALUES
+0 on success, -errno otherwise.
+
+.SH AUTHORS
+${AUTHORS}
+
+.SH SEE ALSO
+${SEEALSO3}

--- a/plfs.spec
+++ b/plfs.spec
@@ -138,9 +138,11 @@ fi
 %{_mandir}/man3/plfs_closedir_c.3.gz
 %{_mandir}/man3/plfs_create.3.gz
 %{_mandir}/man3/plfs_flatten_index.3.gz
+%{_mandir}/man3/plfs_flush_writes.3.gz
 %{_mandir}/man3/plfs_getattr.3.gz
 %{_mandir}/man3/plfs_get_filetype.3.gz
 %{_mandir}/man3/plfs_getxattr.3.gz
+%{_mandir}/man3/plfs_invalidate_read_cache.3.gz
 %{_mandir}/man3/plfs_link.3.gz
 %{_mandir}/man3/plfs_mkdir.3.gz
 %{_mandir}/man3/plfs_mode.3.gz

--- a/src/LogicalFS/LogicalFS.h
+++ b/src/LogicalFS/LogicalFS.h
@@ -41,6 +41,8 @@ class
         virtual int rmdir(const char *path) = 0;
         virtual int symlink(const char *path, const char *to) = 0;
         virtual int statvfs(const char *path, struct statvfs *stbuf) = 0;
+        virtual int flush_writes(const char *dir) {return 0;};
+        virtual int invalidate_cache(const char *dir) {return 0;};
 };
 
 #endif

--- a/src/LogicalFS/SmallFile/SmallFileFS.cpp
+++ b/src/LogicalFS/SmallFile/SmallFileFS.cpp
@@ -492,3 +492,36 @@ SmallFileFS::statvfs(const char *path, struct statvfs *stbuf)
     struct plfs_backend *backend = expinfo.pmount->backends[0];
     return backend->store->Statvfs(backend->bmpoint.c_str(), stbuf);
 }
+
+int
+SmallFileFS::invalidate_cache(const char *dir)
+{
+    PathExpandInfo expinfo;
+    ContainerPtr cached_container;
+    string fakename(dir);
+
+    fakename += "/fakename";
+    smallfile_expand_path(fakename.c_str(), expinfo);
+    cached_container = containers.lookup(expinfo.dirpath);
+    if (cached_container) {
+        cached_container->sync_writers(WRITER_SYNC_DATAFILE);
+        containers.erase(expinfo.dirpath);
+    }
+    return 0;
+}
+
+int
+SmallFileFS::flush_writes(const char *dir)
+{
+    PathExpandInfo expinfo;
+    ContainerPtr cached_container;
+    string fakename(dir);
+
+    fakename += "/fakename";
+    smallfile_expand_path(fakename.c_str(), expinfo);
+    cached_container = containers.lookup(expinfo.dirpath);
+    if (cached_container) {
+        cached_container->sync_writers(WRITER_SYNC_DATAFILE);
+    }
+    return 0;
+}

--- a/src/LogicalFS/SmallFile/SmallFileFS.h
+++ b/src/LogicalFS/SmallFile/SmallFileFS.h
@@ -47,6 +47,8 @@ class SmallFileFS : public LogicalFileSystem
         int rmdir(const char *path);
         int symlink(const char *path, const char *to);
         int statvfs(const char *path, struct statvfs *stbuf);
+        int flush_writes(const char *dir);
+        int invalidate_cache(const char *dir);
 };
 
 #endif

--- a/src/plfs.cpp
+++ b/src/plfs.cpp
@@ -618,3 +618,35 @@ int plfs_setxattr(Plfs_fd *fd, const void *value, const char *key, size_t len) {
     debug_exit(__FUNCTION__,fd->getPath(),ret);
     return ret;
 }
+
+int plfs_flush_writes(const char *path)
+{
+    debug_enter(__FUNCTION__,path);
+    int ret = 0;
+    char stripped_path[PATH_MAX];
+    stripPrefixPath(path, stripped_path);
+    LogicalFileSystem *logicalfs = plfs_get_logical_fs(stripped_path);
+    if (logicalfs == NULL) {
+        ret = -EINVAL;
+    } else {
+        ret = logicalfs->flush_writes(stripped_path);
+    }
+    debug_exit(__FUNCTION__,path,ret);
+    return ret;
+}
+
+int plfs_invalidate_read_cache(const char *path)
+{
+    debug_enter(__FUNCTION__,path);
+    int ret = 0;
+    char stripped_path[PATH_MAX];
+    stripPrefixPath(path, stripped_path);
+    LogicalFileSystem *logicalfs = plfs_get_logical_fs(stripped_path);
+    if (logicalfs == NULL) {
+        ret = -EINVAL;
+    } else {
+        ret = logicalfs->invalidate_cache(stripped_path);
+    }
+    debug_exit(__FUNCTION__,path,ret);
+    return ret;
+}

--- a/src/plfs.h.in
+++ b/src/plfs.h.in
@@ -172,6 +172,10 @@ typedef void *Plfs_dirp;
 
     int plfs_sync( Plfs_fd * );
 
+    int plfs_flush_writes( const char *dir );
+
+    int plfs_invalidate_read_cache( const char *dir );
+
     /* Plfs_fd can be NULL, but then path must be valid */
     int plfs_trunc( Plfs_fd *, const char *path, off_t, int open_file );
 


### PR DESCRIPTION
 I add two API to libplfs: plfs_flush(pathname) and plfs_invalidate_cache(pathname). They will provide a consistency guarantee for small file mode as following:
Process A:
    Make some changes to /mnt/plfs/dir1/file1;  // Changeset 1
    Create/delete files in /mnt/plfs/dir1/;       // Changeset 2
    Call plfs_flush(/mnt/plfs/dir1/file1;   // at timestamp 1.

Process B:
    Call plfs_invalidate_cache(/mnt/plfs/dir1/file1);  // at some time after timestamp 1. (barrier could guarantee that order in time).
        plfs_open(/mnt/plfs/dir1/file1, ...);
    Then process B is guaranteed to see the changes in Changeset 1 and Changeset 2.

I've modified fs_test tool to test it. I add plfs_invalidate_cache(target) right after the barrier() before read()/write(), and then run fs_test.x with --io plfs --barrier bread,bwrite. Then the fs_test.x tool succeed without errors.
