### PR TITLE
Enum and non-enum use in conditionals

### DIFF
--- a/src/Container.h
+++ b/src/Container.h
@@ -32,8 +32,12 @@ class IOSDirHandle;
 #define DROPPING_MODE  (S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH)//Container::dropping_mode()
 #define CONTAINER_MODE (DROPPING_MODE | S_IXUSR |S_IXGRP | S_IXOTH)
 
-// add a type to types in readdir() so we can diff btwn logical dir and containr
-#define DT_CONTAINER (unsigned char)-1
+// add a type to types in dirent.h so we can diff between a logical dir and a container
+enum   
+{
+    DT_CONTAINER = (unsigned char)-1
+#define DT_CONTAINER DT_CONTAINER
+};
 
 enum
 parentStatus {


### PR DESCRIPTION
Fix to make conditionals using DT_CONTAINER like play nice with the dirent.h legacy define and enum d_type. For example, (is_container?DT_CONTAINER:DT_DIR).

This technique is described at http://gcc.gnu.org/onlinedocs/gcc-4.6.2/cpp/Self_002dReferential-Macros.html#Self_002dReferential-Macros
