### PR TITLE
Move fileid map in SMF_Writer to SmallFileFD

### DIFF
--- a/src/LogicalFS/SmallFile/SmallFileFD.h
+++ b/src/LogicalFS/SmallFile/SmallFileFD.h
@@ -60,6 +60,10 @@ class Small_fd : public Plfs_fd, public PLFSIndex
         pid_t open_by_pid;
         string path_;
         string myName;
+        map<ssize_t, FileID> idmap_;
+        pthread_rwlock_t fileids_lock;
+
+        FileID get_fileid(const WriterPtr &writer);
 };
 
 #endif

--- a/src/LogicalFS/SmallFile/SmallFileFS.cpp
+++ b/src/LogicalFS/SmallFile/SmallFileFS.cpp
@@ -350,12 +350,17 @@ SmallFileFS::trunc(const char *logical, off_t offset, int open_file)
 {
     PathExpandInfo expinfo;
     ContainerPtr container;
+    WriterPtr writer;
     int ret;
+    FileID fileid;
     smallfile_expand_path(logical, expinfo);
     container = get_container(expinfo);
     if (!container || !container->file_exist(expinfo.filename))
         return -ENOENT;
-    ret = container->truncate(expinfo.filename, offset, getpid());
+    writer = container->get_writer(getpid());
+    fileid = writer->get_fileid(expinfo.filename, &container->files);
+    ret = writer->truncate(fileid, offset, NULL, NULL);
+    if (ret == 0) container->files.truncate_file(expinfo.filename, offset);
     return ret;
 }
 

--- a/src/LogicalFS/SmallFile/smallfile/NamesMapping.cpp
+++ b/src/LogicalFS/SmallFile/smallfile/NamesMapping.cpp
@@ -89,19 +89,28 @@ NamesMapping::merge_object(void *record, void *metadata) {
         case SM_DELETE:
             metadata_cache.erase(filename);
             break;
-        case SM_OPEN:
-        case SM_CREATE: {
+        case SM_OPEN: {
             index_mapping_t *index_info = (index_mapping_t *)metadata;
+            map<string, FileMetaDataPtr>::iterator itr;
+            itr = metadata_cache.find(filename);
+            if (itr == metadata_cache.end()) {
+                mlog(SMF_ERR, "Open a nonexist file: %s.", filename.c_str());
+            } else {
+                itr->second->mtime = op_time;
+                itr->second->index_mapping.push_back(*index_info);
+            }
+            break;
+        }
+        case SM_CREATE: {
             map<string, FileMetaDataPtr>::iterator itr;
             itr = metadata_cache.find(filename);
             if (itr == metadata_cache.end()) {
                 FileMetaDataPtr temp_ptr(new FileMetaData);
                 temp_ptr->mtime = op_time;
-                temp_ptr->index_mapping.push_back(*index_info);
                 metadata_cache[filename] = temp_ptr;
             } else {
-                itr->second->mtime = op_time;
-                itr->second->index_mapping.push_back(*index_info);
+                mlog(SMF_INFO, "File %s is created multiple times.",
+                     filename.c_str());
             }
             break;
         }

--- a/src/LogicalFS/SmallFile/smallfile/SMF_Writer.hxx
+++ b/src/LogicalFS/SmallFile/smallfile/SMF_Writer.hxx
@@ -50,12 +50,9 @@ private:
     /* The above members are protected by ResourceUnit::item_lock (rwlock). */
 
     ssize_t dropping_id; /**< Set by the constructor and never changes. */
-    map<string, FileID> open_files;
-    pthread_mutex_t mlock; /**< The lock protects the open_files mapping. */
 
     int add_single_record(const string &, enum SmallFileOps, off_t *,
                           InMemoryCache *);
-    FileID get_fileid(const string &filename, InMemoryCache *meta);
 
 protected:
     /** Check whether the dropping files are created. */
@@ -91,12 +88,14 @@ public:
     int create(const string &filename, InMemoryCache *cached);
     int remove(const string &filename, InMemoryCache *cached);
     int rename(const string &from, const string &to, InMemoryCache *cached);
-    ssize_t write(const string &filename, const void *buf, off_t offset,
+    ssize_t write(const FileID fileid, const void *buf, off_t offset,
                   size_t count, InMemoryCache *meta, InMemoryCache *index);
-    int truncate(const string &filename, off_t offset, InMemoryCache *meta,
+    int truncate(const FileID fileid, off_t offset, InMemoryCache *meta,
                  InMemoryCache *index);
     int utime(const string &filename, struct utimbuf *ut, InMemoryCache *meta);
     int sync(int sync_level);
+    FileID get_fileid(const string &filename, InMemoryCache *meta);
+    ssize_t get_droppingid() const { return dropping_id; };
 };
 
 #endif

--- a/src/LogicalFS/SmallFile/smallfile/SmallFileContainer.cpp
+++ b/src/LogicalFS/SmallFile/smallfile/SmallFileContainer.cpp
@@ -247,32 +247,6 @@ SmallFileContainer::remove(const string &filename, pid_t pid) {
     return ret;
 }
 
-ssize_t
-SmallFileContainer::write(const string &filename, const void *buf,
-                          off_t offset, size_t count, pid_t pid) {
-    WriterPtr writer = get_writer(pid);
-    IndexPtr indexptr = index_cache.lookup(filename);
-    ssize_t ret;
-
-    mlog(SMF_DAPI, "Write %lu@%lu to %s from pid-%lu.",
-         (unsigned long)count, (unsigned long)offset,
-         filename.c_str(), (unsigned long)pid);
-    ret = writer->write(filename, buf, offset, count, &files, indexptr.get());
-    if (ret > 0) files.expand_filesize(filename, offset+ret);
-    return ret;
-}
-
-int
-SmallFileContainer::truncate(const string &filename, off_t offset, pid_t pid) {
-    WriterPtr writer = get_writer(pid);
-    IndexPtr indexptr = index_cache.lookup(filename);
-    int ret;
-
-    ret = writer->truncate(filename, offset, &files, indexptr.get());
-    if (ret == 0) files.truncate_file(filename, offset);
-    return ret;
-}
-
 int
 SmallFileContainer::utime(const string &filename, struct utimbuf *ut,
                           pid_t pid)

--- a/src/LogicalFS/SmallFile/smallfile/SmallFileContainer.hxx
+++ b/src/LogicalFS/SmallFile/smallfile/SmallFileContainer.hxx
@@ -46,12 +46,10 @@ public:
     int create(const string &filename, pid_t pid);
     int rename(const string &from, const string &to, pid_t pid);
     int remove(const string &filename, pid_t pid);
-    ssize_t write(const string &filename, const void *buf, off_t offset,
-                  size_t count, pid_t pid);
-    int truncate(const string &filename, off_t offset, pid_t pid);
     int utime(const string &filename, struct utimbuf *ut, pid_t pid);
 
     int delete_if_empty();
+    WriterPtr get_writer(pid_t pid);
     int sync_writers(int sync_level);
 
     NamesMapping files;
@@ -72,7 +70,6 @@ private:
     pthread_rwlock_t writers_lock;
 
     int makeTopLevelDir(plfs_backend *, const string &, const string &);
-    WriterPtr get_writer(pid_t pid);
     void clear_chunk_cache();
 };
 


### PR DESCRIPTION
So that only the file id mapping entries for open files are cached
in memory.
