### PR TITLE
Rewrite of plfsrc.example, updated README.install, and added a 1.7.x patch for openmpi

### DIFF
--- a/README.install
+++ b/README.install
@@ -3,7 +3,8 @@
    tools/plfs_check_config after building PLFS. Please note that the plfsrc
    file format has changed as of version 2.4. Any old plfsrc's not in the new
    YAML format need to be edited to conform to the new standard before updating
-   to 2.4 or above.
+   to 2.4 or above. For more examples and full details of all configuration 
+   options please see the plfsrc man page located in man/man5.
 
 1) Build the PLFS library and supporting tools.
 

--- a/mpi_adio/patches/openmpi/ompi-1.7.x-plfs-prep.patch
+++ b/mpi_adio/patches/openmpi/ompi-1.7.x-plfs-prep.patch
@@ -1,0 +1,194 @@
+--- openmpi-1.6/ompi/mca/io/romio/romio/configure.in	2012-04-03 08:30:23.000000000 -0600
++++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/configure.in	2012-05-16 12:23:49.670589000 -0600
+@@ -144,7 +144,7 @@
+ #
+ have_aio=no
+ #
+-known_filesystems="nfs ufs pfs pvfs pvfs2 testfs xfs panfs gridftp lustre bgl bglockless zoidfs"
++known_filesystems="nfs ufs pfs pvfs pvfs2 testfs xfs panfs plfs gridftp lustre bgl bglockless zoidfs"
+ # Open MPI: added "open_mpi_mpi"
+ known_mpi_impls="mpich2_mpi mpich_mpi sgi_mpi hp_mpi cray_mpi lam_mpi open_mpi_mpi"
+ #
+@@ -1175,6 +1175,9 @@
+ if test -n "$file_system_panfs"; then
+     AC_DEFINE(ROMIO_PANFS,1,[Define for ROMIO with PANFS])
+ fi
++if test -n "$file_system_plfs"; then
++    AC_DEFINE(ROMIO_PLFS,1,[Define for ROMIO with PLFS])
++fi
+ if test -n "$file_system_ufs"; then
+     AC_DEFINE(ROMIO_UFS,1,[Define for ROMIO with UFS])
+ fi
+@@ -2126,7 +2129,7 @@
+ 
+ # Open MPI: setup the AM_CONDITIONALs to build the different adio devices
+  m4_foreach([my_fs], 
+-  [bgl, bglockless, gridftp, lustre, nfs, panfs, pfs, pvfs, pvfs2, sfs, testfs, ufs, xfs, zoidfs],
++  [bgl, bglockless, gridftp, lustre, nfs, panfs, pfs, pvfs, pvfs2, sfs, testfs, ufs, xfs, zoidfs, plfs],
+   [AM_CONDITIONAL(BUILD_[]AS_TR_CPP(my_fs), [test -n "$file_system_]my_fs["])])
+ 
+ echo "setting CC to $CC"
+@@ -2255,6 +2258,7 @@
+     adio/ad_nfs/Makefile 
+     adio/ad_ntfs/Makefile 
+     adio/ad_panfs/Makefile
++    adio/ad_plfs/Makefile
+     adio/ad_pfs/Makefile
+     adio/ad_pvfs/Makefile
+     adio/ad_pvfs2/Makefile
+diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/README openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/README
+--- openmpi-1.6/ompi/mca/io/romio/romio/README	2012-04-03 08:30:23.000000000 -0600
++++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/README	2012-05-16 12:25:38.517012000 -0600
+@@ -1,5 +1,14 @@
+           ROMIO: A High-Performance, Portable MPI-IO Implementation
+ 
++                      Version 2012-05-16
++
++Major Changes in this version:
++------------------------------
++* added PLFS support
++  http://sourceforge.net/projects/plfs/
++  http://institutes.lanl.gov/plfs/
++
++
+                       Version 2008-03-09
+ 
+ Major Changes in this version:
+diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/adio/Makefile.am openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/Makefile.am
+--- openmpi-1.6/ompi/mca/io/romio/romio/adio/Makefile.am	2012-04-03 08:30:23.000000000 -0600
++++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/Makefile.am	2012-05-16 12:19:54.561579000 -0600
+@@ -87,6 +87,14 @@
+ PANFS_LIB =
+ endif
+ 
++if BUILD_PLFS
++PLFS_DIR = ad_plfs
++PLFS_LIB = ad_plfs/libadio_plfs.la
++else
++PLFS_DIR =
++PLFS_LIB =
++endif
++
+ if BUILD_PFS
+ PFS_DIR = ad_pfs
+ PFS_LIB = ad_pfs/libadio_pfs.la
+@@ -163,11 +171,11 @@
+ SUBDIRS = common include \
+ 	$(BG_DIR) $(BGLOCKLESS_DIR) \
+ 	$(GRIDFTP_DIR) $(LUSTRE_DIR) $(NFS_DIR) $(NTFS_DIR) $(PANFS_DIR) \
+-	$(PFS_DIR) $(PVFS_DIR) $(PVFS2_DIR) $(SFS_DIR) \
++	$(PLFS_DIR) $(PFS_DIR) $(PVFS_DIR) $(PVFS2_DIR) $(SFS_DIR) \
+ 	$(TESTFS_DIR) $(UFS_DIR) $(XFS_DIR) $(ZOID_DIR)
+ DIST_SUBDIRS = common include \
+         ad_bgl ad_bglockless ad_gridftp ad_lustre ad_nfs ad_ntfs \
+-        ad_panfs ad_pfs ad_pvfs	ad_pvfs2 ad_sfs ad_testfs ad_ufs \
++        ad_panfs ad_plfs ad_pfs ad_pvfs	ad_pvfs2 ad_sfs ad_testfs ad_ufs \
+         ad_xfs ad_zoidfs
+ 
+ # Library
+@@ -177,5 +185,5 @@
+         common/libadio_common.la \
+ 	$(BG_LIB) $(BGLOCKLESS_LIB) \
+         $(GRIDFTP_LIB) $(LUSTRE_LIB) $(NFS_LIB) $(NTFS_LIB) $(PANFS_LIB) \
+-        $(PFS_LIB) $(PVFS_LIB) $(PVFS2_LIB) $(SFS_LIB) \
++        $(PLFS_LIB) $(PFS_LIB) $(PVFS_LIB) $(PVFS2_LIB) $(SFS_LIB) \
+         $(TESTFS_LIB) $(UFS_LIB) $(XFS_LIB) $(ZOID_LIB)
+diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/adio/common/ad_fstype.c openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/common/ad_fstype.c
+--- openmpi-1.6/ompi/mca/io/romio/romio/adio/common/ad_fstype.c	2012-04-03 08:30:22.000000000 -0600
++++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/common/ad_fstype.c	2012-05-16 12:06:22.160728000 -0600
+@@ -510,6 +510,9 @@
+     else if (!strncmp(filename, "panfs:", 6) || !strncmp(filename, "PANFS:", 6)) {
+ 	*fstype = ADIO_PANFS;
+     }
++    else if (!strncmp(filename, "plfs:", 5) || !strncmp(filename, "PLFS:", 5)) {
++	*fstype = ADIO_PLFS;
++    }
+     else if (!strncmp(filename, "hfs:", 4) || !strncmp(filename, "HFS:", 4)) {
+ 	*fstype = ADIO_HFS;
+     }
+@@ -712,6 +715,16 @@
+ 	*ops = &ADIO_PANFS_operations;
+ #endif
+     }
++    if (file_system == ADIO_PLFS) {
++#ifndef ROMIO_PLFS
++	*error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
++					   myname, __LINE__, MPI_ERR_IO,
++					   "**iofstypeunsupported", 0);
++	return;
++#else
++	*ops = &ADIO_PLFS_operations;
++#endif
++    }
+     if (file_system == ADIO_HFS) {
+ #ifndef ROMIO_HFS
+ 	*error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/adio/common/ad_opencoll.c openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/common/ad_opencoll.c
+--- openmpi-1.6/ompi/mca/io/romio/romio/adio/common/ad_opencoll.c	2012-04-03 08:30:22.000000000 -0600
++++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/common/ad_opencoll.c	2012-05-16 11:59:12.594192000 -0600
+@@ -80,7 +80,7 @@
+    in fd, so that get_amode returns the right answer. */
+ 
+     orig_amode_wronly = access_mode;
+-    if (access_mode & ADIO_WRONLY) {
++    if (access_mode & ADIO_WRONLY && fd->file_system != ADIO_PLFS) {
+ 	access_mode = access_mode ^ ADIO_WRONLY;
+ 	access_mode = access_mode | ADIO_RDWR;
+     }
+diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/adio/include/adio.h openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/include/adio.h
+--- openmpi-1.6/ompi/mca/io/romio/romio/adio/include/adio.h	2012-04-03 08:30:21.000000000 -0600
++++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/include/adio.h	2012-05-16 12:08:40.191472000 -0600
+@@ -300,6 +300,7 @@
+ #define ADIO_LUSTRE              163   /* Lustre */
+ #define ADIO_BGL                 164   /* IBM BGL */
+ #define ADIO_BGLOCKLESS          165   /* IBM BGL (lock-free) */
++#define ADIO_PLFS                166   /* PLFS */
+ #define ADIO_ZOIDFS              167   /* ZoidFS: the I/O forwarding fs */
+ 
+ #define ADIO_SEEK_SET            SEEK_SET
+diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/adio/include/adioi_errmsg.h openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/include/adioi_errmsg.h
+--- openmpi-1.6/ompi/mca/io/romio/romio/adio/include/adioi_errmsg.h	2012-04-03 08:30:21.000000000 -0600
++++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/include/adioi_errmsg.h	2012-05-16 12:10:22.277350000 -0600
+@@ -42,7 +42,7 @@
+ 
+ MPI_ERR_IO
+     MPIR_ERR_ETYPE_FRACTIONAL "Only an integral number of etypes can be accessed"
+-    MPIR_ERR_NO_FSTYPE "Can't determine the file-system type. Check the filename/path you provided and try again. Otherwise, prefix the filename with a string to indicate the type of file sytem (piofs:, pfs:, nfs:, ufs:, hfs:, xfs:, sfs:, pvfs:, panfs: ftp: gsiftp:)"
++    MPIR_ERR_NO_FSTYPE "Can't determine the file-system type. Check the filename/path you provided and try again. Otherwise, prefix the filename with a string to indicate the type of file sytem (piofs:, pfs:, nfs:, ufs:, hfs:, xfs:, sfs:, pvfs:, panfs: plfs: ftp: gsiftp:)"
+     MPIR_ERR_NO_PFS "ROMIO has not been configured to use the PFS file system"
+     MPIR_ERR_NO_PIOFS "ROMIO has not been configured to use the PIOFS file system"
+     MPIR_ERR_NO_UFS "ROMIO has not been configured to use the UFS file system"
+@@ -52,6 +52,7 @@
+     MPIR_ERR_NO_SFS "ROMIO has not been configured to use the SFS file system"
+     MPIR_ERR_NO_PVFS "ROMIO has not been configured to use the PVFS file system"
+     MPIR_ERR_NO_PANFS "ROMIO has not been configured to use the PANFS file system"
++    MPIR_ERR_NO_PLFS "ROMIO has not been configured to use the PLFS file system"
+     MPIR_ERR_MULTIPLE_SPLIT_COLL "Only one active split collective I/O operation allowed per file handle"
+     MPIR_ERR_NO_SPLIT_COLL "No previous split collective begin"
+     MPIR_ERR_ASYNC_OUTSTANDING "There are outstanding nonblocking I/O operations on this file"
+diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/adio/include/adioi_fs_proto.h openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/include/adioi_fs_proto.h
+--- openmpi-1.6/ompi/mca/io/romio/romio/adio/include/adioi_fs_proto.h	2012-04-03 08:30:21.000000000 -0600
++++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/include/adioi_fs_proto.h	2012-05-16 12:11:31.868131000 -0600
+@@ -19,6 +19,11 @@
+ /* prototypes are in adio/ad_panfs/ad_panfs.h */
+ #endif
+ 
++#ifdef ROMIO_PLFS
++extern struct ADIOI_Fns_struct ADIO_PLFS_operations;
++/* prototypes are in adio/ad_plfs/ad_plfs.h */
++#endif
++
+ #ifdef ROMIO_PFS
+ extern struct ADIOI_Fns_struct ADIO_PFS_operations;
+ /* prototypes are in adio/ad_pfs/ad_pfs.h */
+diff -Naur openmpi-1.6/ompi/mca/io/romio/romio/adio/include/mpio_error.h openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/include/mpio_error.h
+--- openmpi-1.6/ompi/mca/io/romio/romio/adio/include/mpio_error.h	2012-04-03 08:30:21.000000000 -0600
++++ openmpi-1.6_patch-plfs/ompi/mca/io/romio/romio/adio/include/mpio_error.h	2012-05-16 12:12:25.041976000 -0600
+@@ -52,6 +52,7 @@
+ #define MPIR_ERR_NO_HFS 15
+ #define MPIR_ERR_NO_XFS 17
+ #define MPIR_ERR_NO_SFS 19
++#define MPIR_ERR_NO_PLFS 20
+ #define MPIR_ERR_NO_PVFS 21
+ #define MPIR_ERR_NO_PANFS 22
+ #define MPIR_ERR_MULTIPLE_SPLIT_COLL 23

--- a/plfsrc.example
+++ b/plfsrc.example
@@ -1,93 +1,17 @@
-# also check man 5 plfsrc for more info about this file and more examples
-#
-###############
-# plfsrc rules
-###############
-# 
-# Official rule:
-# The backends directive is IMMUTABLE.  Once a mount point is defined, the
-# backends can NEVER be changed.  If multiple machines (e.g. FTA's and multiple
-# clusters) share a PLFS mount point, they must all define the same exact set of
-# backends in the same exact ordering.
-# 
-# All other directives are merely hints and can be set to any value without
-# affecting correctness. 
-# 
-# Explanation:
-# Once a mount point is assigned a set of backends, the mapping between that
-# mount point and that set of backends can NEVER be changed.  Changing backends
-# for an existing mount point WILL ORPHAN files on that mount point.  If multiple
-# clusters and FTA's share a PLFS mount point, they MUST have the same exact set
-# of backends, in the same exact order, defined for that mount point.
-# 
-# NO OTHER values in the plfsrc affect correctness.  They are just hints to help
-# with performance.  Therefore we can safely have different values for
-# threadpool_size and num_hostdirs on different machines even if those machines
-# share a mount point.  We can change values for threadpool_size and num_hostdirs
-# whenever we want.  Existing files will not be adversely affected in any way
-# although performance may change.
+# Below is a very simple configuration example to get you started.
+# For more detail, explanations, and examples please see the plfsrc man page
+# located in man/man5/
 
 
-#################
-# num_hostdirs:
-# this should be set to a number near the square root of the total number of
-# PE's on the system
-#################
-# 
-# Official rule:
-# Let N be the size in PE's of the largest job that will be run on the system.
-# Let S be the sqrt of that.
-# Let P be the lowest prime number greater than or equal to S.
-# Set num_hostdirs to be P.
-# 
-# For example, say that the largest job that can be run on cluster C is 10K PEs.
-# num_hostdirs should be set to 101.
-# 
-# Explanation:
-# 
-# PLFS stores file data and file metadata in a PLFS structure called a container
-# which is built using directories and files on an underlying file system.  The
-# number of files within a container is basically equal to the number of PE's
-# that wrote the file.  We store these files within subdirs within the container.
-# At exascale, we might have a billion cores and we cannot put a billion files in
-# a single directory.  Therefore we use num_hostdirs to create a balanced internal
-# hierarchy within the container.  If there are 10K PE's, this means that we will
-# have 100 hostdirs and each of those hostdirs will have 100 files in them.  However,
-# the distribution of files into subdirs is not deterministic; rather we rely on
-# hashing.  Hashing plays well with prime numbers; that's why we do the prime number
-# bit.
-# 
-# [This means that for 1B cores, we will have about 30K files per directory.  We
-# might need to move to a 3 level hierarchy for exascale.]
-
-###############
-# threadpool_size:
-# this should be related to how many threads you want running on a machine
-###############
-#
-# Official rule:
-# If compute node, 1.  If FTA, 16.
-# 
-# Explanation:
-# We observed that for two different read operations, the FTA performance was
-# very low due to a lack of concurrency resulting in too few PanFS components
-# being engaged.  One operation was reading all the multiple index files within
-# the container which PLFS does on the read open().  The second was reading from
-# multiple data files within the container to fill in a large logical read.  We
-# then added threads to increase concurrency, engage more PanFS hardware, and got
-# much better results.  But we assume that large jobs run on the compute nodes so
-# we don't want to add even more concurrency since the large number of PE's
-# should provide sufficient concurrency to engage all of the PanFS hardware; in
-# fact, adding more streams can hurt per client PanFS performance.  This is just
-# a performance hint; it can be set to any value without affecting correctness.
-
-#- global_params:
-#  threadpool_size 1
-#  num_hostdirs: 41
+# these parameters apply to ALL mount points
+- global_params:
+  threadpool_size: 1
+  num_hostdirs: 41
 
 # this must match where FUSE is mounted and the logical paths passed to ADIO
-# - mount_point: /tmp/plfs
+ - mount_point: /path/to/plfs/mount/point
 
-# these must be full paths, can be just a single one
-#   backends:
-#    - location: /tmp/.plfs_store
+# at least one location is needed, more can be specified
+   backends:
+    - location: /path/to/plfs/backend/.plfs_store
+   workload: N-1


### PR DESCRIPTION
Not sure why it lists 3 commits (the last one listed is the only one not already merged).

The 1.7.x patch passes my initial tests with the regression suite and does build openmpi successfully.  It is literally just a copy of the 1.6.x patch.
