### PR TITLE
spec file updated to not create and remove default PLFS mount points and backends.

### DIFF
--- a/plfs.spec
+++ b/plfs.spec
@@ -85,7 +85,6 @@ if [ "$1" = "1" ]; then
    if [ -x /sbin/chkconfig ] ; then
        /sbin/chkconfig --add plfs
    fi
-   mkdir -p /tmp/plfs /tmp/.plfs_store
 fi
 
 %preun
@@ -94,7 +93,6 @@ if [ "$1" = "0" ]; then
     if [ -x /sbin/chkconfig ] ; then
         /sbin/chkconfig --del plfs
     fi
-   rmdir  /tmp/plfs /tmp/.plfs_store
 fi
 
 %files


### PR DESCRIPTION
Since we are no longer providing plfsrc.example and putting it in as
/etc/plfsrc, there is no default plfs configuration. Therefore, it is
not necessary for the plfs rpm to do anything with the old plfs
directories.
