### PR TITLE
Compiler warning + static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,11 @@ if (NOT APPLE)
     set (CMAKE_MODULE_LINKER_FLAGS "-dynamic -Wl,--enable-new-dtags")
 endif()
 
+#yaml-cpp which we call plfs-yaml to avoid conflicts
+add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/src/Plfsrc/yaml-cpp ${PLFS_BUILD_DIR}/yaml-cpp)
+include_directories (src/Plfsrc/yaml-cpp/include)
+include_directories (src/Plfsrc/yaml-cpp/boost)
+
 #static and shared both same name
 add_library(plfs_lib SHARED ${SRCDIR})
 SET_TARGET_PROPERTIES(plfs_lib PROPERTIES OUTPUT_NAME plfs)
@@ -252,6 +257,7 @@ set_target_properties(plfs_lib PROPERTIES
         SOVERSION "${plfs_VERSION_MAJOR}.${plfs_VERSION_MINOR}"
         PROJECT_LABEL "plfs_lib shared")
 
+target_link_libraries (plfs_lib plfs-yaml)
 if (NOT DISABLE_STATIC_LIB)
     add_library(plfs_lib_static STATIC ${SRCDIR})
     #make sure these build first, causes issues in 2.6
@@ -265,6 +271,7 @@ if (NOT DISABLE_STATIC_LIB)
         VERSION "${plfs_VERSION_FULL}"
         SOVERSION "${plfs_VERSION_MAJOR}.${plfs_VERSION_MINOR}"
         PROJECT_LABEL "plfs_lib static")
+    target_link_libraries(plfs_lib_static plfs-yaml-static)
 else()
     INSTALL(TARGETS plfs_lib
             LIBRARY DESTINATION ${LIBDIR})
@@ -283,11 +290,6 @@ if (Threads_FOUND)
     target_link_libraries (plfs_lib ${CMAKE_THREAD_LIBS_INIT})
 endif (Threads_FOUND)
 
-#yaml-cpp which we call plfs-yaml to avoid conflicts
-add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/src/Plfsrc/yaml-cpp ${PLFS_BUILD_DIR}/yaml-cpp)
-target_link_libraries (plfs_lib plfs-yaml)
-include_directories (src/Plfsrc/yaml-cpp/include)
-include_directories (src/Plfsrc/yaml-cpp/boost)
 
 #statvfs
 check_include_files(sys/statvfs.h HAVE_SYS_STATVFS_H)

--- a/src/FileOp.cpp
+++ b/src/FileOp.cpp
@@ -60,7 +60,7 @@ int Access( const string& path, IOStore *store, int mask )
     // will exist if the container exists
     // doing just Access is insufficient when plfs daemon run as root
     // root can access everything.  so, we must also try the open
-    mode_t open_mode;
+    mode_t open_mode = 0;
     int ret;
     IOSHandle *fh;
     bool mode_set=false;

--- a/src/LogicalFS/Container/Container.cpp
+++ b/src/LogicalFS/Container/Container.cpp
@@ -815,7 +815,7 @@ Container::createMetalink(struct plfs_backend *canback,
     string canonical_path_without_id;   /* canonical hostdir bpath w/o id */
     ostringstream oss, shadow;
     size_t i;
-    int ret, id, dir_id;
+    int ret = 0, id = 0, dir_id = 0;
 
     ret = -EIO;  /* to be safe */
 
@@ -844,7 +844,7 @@ Container::createMetalink(struct plfs_backend *canback,
      * our number is busy, we try the next.  if we can't find a free
      * slot, we can just use a hostdir from the canonical container.
      */
-    for (i = 0, dir_id = -1 ; i < pconf->num_hostdirs ; i++) {
+    for ( i = 0, dir_id = -1 ; i < (unsigned int) pconf->num_hostdirs ; i++) {
         /* start with current and go from there, wrapping as needed... */
         id = (current_hostdir + i) % pconf->num_hostdirs;
 
@@ -1857,7 +1857,7 @@ Container::makeHostDir(const ContainerPaths& paths,mode_t mode,
             // loop all possible hostdir # to try to make subdir
             // directory or use the first existing one 
             // (or try to find a valid metalink if all else fails)
-            for(size_t i = 0; i < pconf->num_hostdirs; i ++ ) {
+            for(size_t i = 0; i < (unsigned int) pconf->num_hostdirs; i ++ ) {
                 id = (current_hostdir + i)%pconf->num_hostdirs;
                 oss.str(std::string());
                 oss << canonical_path_without_id << id;

--- a/src/LogicalFS/Container/Index/WriteFile.cpp
+++ b/src/LogicalFS/Container/Index/WriteFile.cpp
@@ -350,7 +350,7 @@ ssize_t
 WriteFile::write(const char *buf, size_t size, off_t offset, pid_t pid)
 {
     int ret = 0;
-    ssize_t written;
+    ssize_t written = 0;
 
     ret = prepareForWrite( pid );
     if ( ret == 0 ) {

--- a/src/LogicalFS/SmallFile/SmallFileFS.cpp
+++ b/src/LogicalFS/SmallFile/SmallFileFS.cpp
@@ -115,8 +115,8 @@ SmallFileFS::chown(const char *logical, uid_t u, gid_t g)
 {
     PathExpandInfo expinfo;
     int firsttime = 1;
-    int ret;
-    struct plfs_backend *backend;
+    int ret = 0;
+    struct plfs_backend *backend = NULL;
 
     smallfile_expand_path(logical, expinfo);
     for (int i = 0; i < expinfo.pmount->nback; i++) {

--- a/src/LogicalFS/SmallFile/smallfile/InMemoryCache.cpp
+++ b/src/LogicalFS/SmallFile/smallfile/InMemoryCache.cpp
@@ -30,6 +30,7 @@ InMemoryCache::resource_available(int type, void *resource) {
     } else {
         assert(0);
     }
+    return false;
 }
 
 int

--- a/src/LogicalFS/SmallFile/smallfile/SMF_Writer.cpp
+++ b/src/LogicalFS/SmallFile/smallfile/SMF_Writer.cpp
@@ -39,6 +39,7 @@ SMF_Writer::resource_available(int type, void *resource) {
     default:
         assert(0);
     }
+    return -1;
 }
 
 int
@@ -263,7 +264,7 @@ SMF_Writer::get_fileid(const string &filename, InMemoryCache *meta) {
 
 int
 SMF_Writer::sync(int sync_level) {
-    int ret;
+    int ret = 0;
     switch (sync_level) {
     case WRITER_SYNC_DATAFILE:
         ret = data_file.sync();

--- a/src/LogicalFS/SmallFile/smallfile/SmallFileContainer.cpp
+++ b/src/LogicalFS/SmallFile/smallfile/SmallFileContainer.cpp
@@ -116,7 +116,7 @@ SmallFileContainer::get_writer(pid_t pid) {
         pthread_rwlock_unlock(&writers_lock);
         return retval;
     }
-    if (writers.size() >= pmount->max_writers) {
+    if (writers.size() >= (unsigned int) pmount->max_writers) {
         // If there are too many writers already, we borrow one from another
         // process instead of creating a new one ourselves.
         itr = writers.begin();

--- a/src/Plfsrc/parse_conf.cpp
+++ b/src/Plfsrc/parse_conf.cpp
@@ -157,7 +157,7 @@ is_valid_node(const YAML::Node node, string** bad_key) {
         }
     }
     else if (node.IsSequence()) {
-        for(int i = 0; i < node.size(); i++)
+        for(unsigned int i = 0; i < node.size(); i++)
             if(!is_valid_node(node[i],bad_key)) // recurse
                 return false;
     }

--- a/src/plfs_private.cpp
+++ b/src/plfs_private.cpp
@@ -200,7 +200,7 @@ expandPath(string logical, ExpansionInfo *exp_info,
     // choose a backend unless the caller explicitly requested one
     // also set the set of backends to use.  If the plfsrc has separate sets
     // for shadows and for canonical, then use them appropriately
-    int hash_val, backcnt;
+    int hash_val = 0, backcnt = 0;
     struct plfs_backend **backends = NULL;
     switch(hash_method) {
     case EXPAND_CANONICAL:

--- a/tools/plfs_ls.cpp
+++ b/tools/plfs_ls.cpp
@@ -12,7 +12,7 @@ void show_usage(char* app_name) {
 
 int main (int argc, char **argv) {
     int i;
-    char *target;
+    char *target = NULL;
     bool found_target = false;
     for (i = 1; i < argc; i++) {
         plfs_handle_version_arg(argc, argv[i]);

--- a/tools/plfs_map.cpp
+++ b/tools/plfs_map.cpp
@@ -10,7 +10,7 @@ void show_usage(char* app_name) {
 
 int main (int argc, char **argv) {
     int i;
-    char *target;
+    char *target = NULL;
     bool found_target = false;
     int uniform_restart = false;
     pid_t uniform_rank = 0;

--- a/tools/plfs_query.cpp
+++ b/tools/plfs_query.cpp
@@ -122,7 +122,7 @@ logical_from_physical(char * physical_target, std::string &file_location) {
 int 
 main (int argc, char **argv) {
     int i;
-    char * target;
+    char *target = NULL;
     bool found_target = false;
     string dir_suffix = "";
     string metalink_suffix = "";


### PR DESCRIPTION
fixed a bunch of warnings found using a new compiler, mostly uninitalized variables and comparing signed to unsigned variables. Also fixed the build process for static plfs -- it now links with static yaml
