### PR TITLE
Add class URI to parse the backend spec string

### DIFF
--- a/src/IOStore/URI.cpp
+++ b/src/IOStore/URI.cpp
@@ -1,0 +1,23 @@
+#include "URI.h"
+#include <regex.h>
+
+#define SUBEXP(uri, match, i) \
+    std::string(&uri[match[i].rm_so], match[i].rm_eo-match[i].rm_so)
+// The regular expression comes from http://tools.ietf.org/html/rfc3986
+#define URIRE "^\\(\\([^:/?#]\\+\\):\\)\\?\\(//\\([^/?#]*\\)\\)\\?\\([^?#]*\\)"
+
+URI::URI(const char *uri)
+{
+    regex_t re;
+    _error = regcomp(&re, URIRE, 0);
+    if (_error == 0) {
+        regmatch_t matchptr[6];
+        _error = regexec(&re, uri, 6, matchptr, 0);
+        if (_error == 0) {
+            _scheme = SUBEXP(uri, matchptr, 1);
+            _authority = SUBEXP(uri, matchptr, 3);
+            _path = SUBEXP(uri, matchptr, 5);
+        }
+        regfree(&re);
+    }
+}

--- a/src/IOStore/URI.h
+++ b/src/IOStore/URI.h
@@ -1,0 +1,34 @@
+#ifndef PLFS_IOSTORE_URI_H
+#define PLFS_IOSTORE_URI_H
+
+#include <string>
+
+/**
+ * A simple URI parser based on rfc3986
+ *
+ * The following is an example URI and its component parts:
+ *
+ *       foo://example.com:8042/over/there?name=ferret#nose
+ *       \__/\________________/\_________/ \_________/ \__/
+ *        |           |            |            |        |
+ *     scheme     authority       path        query   fragment
+ *
+ * This class doesn't handle the query and fragment parts, they
+ * are just ignored if specified.
+ */
+
+class URI {
+public:
+    URI(const char *uri);
+    const std::string &getScheme() const {return _scheme;};
+    const std::string &getAuthority() const {return _authority;};
+    const std::string &getPath() const {return _path;};
+    int getError() const {return _error;};
+private:
+    std::string _scheme;
+    std::string _authority;
+    std::string _path;
+    int _error;
+};
+
+#endif


### PR DESCRIPTION
The URI identifier is well specified and commonly used in lots
of places, so we can use this to identify the location of the
given backend.

The most important benefit of using URI is its ability to refer
to resources on different machines, such as:
protocol://host.name.server.1:port1/path/to/some/dir
protocol://host.name.server.2:port2/path/to/some/dir
