### PR TITLE
Update docs with changes that happened in rc4

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -73,6 +73,11 @@ overhead burden that is not necessary. The implementation recognizes their
 existence without actually creating the underlying physical representation if
 there is no data to store.
 
+* Add Werror and Wshadow to default build process
+In order to help keep code to the guidelines outlined in README.developer,
+Werror and Wshadow are now used by default in the build process. Code cleanup
+resulted from this change.
+
 * ADIO Support for newer MPICH
 PLFS-prep patches now exist for MPICH2-1.5 and MPICH-3.0.3. With the release
 of MPICH2-1.5, the MPICH folks completely redid their build system. The

--- a/README.developer
+++ b/README.developer
@@ -20,6 +20,9 @@ treated as errors:
 -DCMAKE_C_FLAGS="-Wall -Werror -Wshadow"
 -DCMAKE_CXX_FLAGS="-Wall -Werror -Wshadow"
 
+It should be noted that for the default build, these compile flags are enabled
+by default.
+
 5) Everything must be code-reviewed before being committed to the master
 branch on github
 The official master branch of PLFS will be referred to as plfs/plfs-core. In


### PR DESCRIPTION
The Changelog and README.developer files now have information about
using Werror and Wshadow on by default.
