### PR TITLE
Fix plfs-yaml lib output name

### DIFF
--- a/src/Plfsrc/yaml-cpp/CMakeLists.txt
+++ b/src/Plfsrc/yaml-cpp/CMakeLists.txt
@@ -139,7 +139,7 @@ if(NOT DISABLE_STATIC_LIB)
 	        VERSION "${YAML_CPP_VERSION}"
 	      	SOVERSION "${YAML_CPP_VERSION_MAJOR}.${YAML_CPP_VERSION_MINOR}"
 		PROJECT_LABEL "plfs-yaml static"
-		OUTPUT_NAME "plfs-yaml-static"
+		OUTPUT_NAME "plfs-yaml"
 	)
 	install(TARGETS plfs-yaml-static ${_INSTALL_DESTINATIONS})
 endif(NOT DISABLE_STATIC_LIB)


### PR DESCRIPTION
I fixed this a few weeks ago but it must have gotten lost when I did my "oops" pushing to master.
