### PR TITLE
Fix some compiler warnings reported by Clang 3.4.0

### DIFF
--- a/src/LogicalFS/Container/container_internals.cpp
+++ b/src/LogicalFS/Container/container_internals.cpp
@@ -1829,7 +1829,7 @@ container_file_version(const char *logical, const char **version)
 {
     PLFS_ENTER;
     struct plfs_pathback pb;
-    ret = ret; // suppress compiler warning
+    (void) ret; // suppress compiler warning
     mode_t mode;
     if (!is_container_file(logical, &mode)) {
         return -ENOENT;

--- a/src/LogicalFS/SmallFile/SmallFileFD.h
+++ b/src/LogicalFS/SmallFile/SmallFileFD.h
@@ -1,5 +1,5 @@
 #ifndef __SMALLFILEFD_H_
-#define __SMALLFILEFD_H__
+#define __SMALLFILEFD_H_
 
 #include "plfs_private.h"
 #include "SmallFileFS.h"

--- a/tests/smallfileunit.cpp
+++ b/tests/smallfileunit.cpp
@@ -26,7 +26,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(NamesMappingUnit);
 CPPUNIT_TEST_SUITE_REGISTRATION(IndexUnit);
 
 extern string plfsmountpoint;
-struct IOStore *store = new PosixIOStore();
+class IOStore *store = new PosixIOStore();
 struct plfs_backend fakeback = {NULL, string("/"), store};
 struct plfs_backend *backend = &fakeback;
 

--- a/tools/dcon.c
+++ b/tools/dcon.c
@@ -161,7 +161,7 @@ static void truncatelog(int ignore) {
      * ignore disabled log files and ftrucate() errors (logfp may not
      * be a file).
      */
-    ignore = ignore; // silence Intel compiler warning
+    (void) ignore; // silence Intel compiler and Clang warning
     if (logfp) {
         (void) ftruncate(fileno(logfp), 0);
     }
@@ -175,7 +175,7 @@ static void truncatelog(int ignore) {
 static void flushlog(int ignore) {
 
     /* XXX: maybe we should make it line buffered? */
-    ignore = ignore; //silence Intel compiler warning
+    (void) ignore; //silence Intel compiler and Clang warning
     if (logfp) {
         fflush(logfp);
     }


### PR DESCRIPTION
Such as:

tools/dcon.c:164:12: error: explicitly assigning a variable of type 'int' to itself [-Werror,-Wself-assign]
    ignore = ignore; // silence Intel compiler warning
    ~~~~~~ ^ ~~~~~~
