### PR TITLE
add the filename info back to LogicalFD trunc() API (for now).

### DIFF
--- a/src/LogicalFS/Container/ContainerFD.cpp
+++ b/src/LogicalFS/Container/ContainerFD.cpp
@@ -60,10 +60,10 @@ Container_fd::sync(pid_t pid)
 }
 
 plfs_error_t
-Container_fd::trunc(off_t offset)
+Container_fd::trunc(off_t offset, struct plfs_physpathinfo *ppip)
 {
     bool open_file = true; // Yes, I am an open file handle.
-    return container_trunc(fd, NULL, offset, open_file);
+    return container_trunc(fd, ppip, offset, open_file);
 }
 
 plfs_error_t

--- a/src/LogicalFS/Container/ContainerFD.h
+++ b/src/LogicalFS/Container/ContainerFD.h
@@ -20,7 +20,7 @@ class Container_fd : public Plfs_fd
                            ssize_t *bytes_written);
         plfs_error_t sync();
         plfs_error_t sync(pid_t pid);
-        plfs_error_t trunc(off_t offset);
+        plfs_error_t trunc(off_t offset, struct plfs_physpathinfo *ppip);
         plfs_error_t getattr(struct stat *stbuf, int sz_only);
         plfs_error_t getxattr(void *value, const char *key, size_t len);
         plfs_error_t setxattr(const void *value, const char *key, size_t len);

--- a/src/LogicalFS/FlatFile/FlatFileFD.h
+++ b/src/LogicalFS/FlatFile/FlatFileFD.h
@@ -24,7 +24,7 @@ class Flat_fd : public Plfs_fd
                            ssize_t *bytes_written);
         plfs_error_t sync();
         plfs_error_t sync(pid_t pid);
-        plfs_error_t trunc(off_t offset);
+        plfs_error_t trunc(off_t offset, struct plfs_physpathinfo *ppip);
         plfs_error_t getattr(struct stat *stbuf, int sz_only);
         plfs_error_t query(size_t *writers, size_t *readers, size_t *bytes_written,
                   bool *reopen);

--- a/src/LogicalFS/FlatFile/FlatFileFD_FS.cpp
+++ b/src/LogicalFS/FlatFile/FlatFileFD_FS.cpp
@@ -136,7 +136,7 @@ Flat_fd::sync(pid_t /* pid */)
 
 /* ret PLFS_SUCCESS or PLFS_E */
 plfs_error_t
-Flat_fd::trunc(off_t offset)
+Flat_fd::trunc(off_t offset, struct plfs_physpathinfo *ppip)
 {
     plfs_error_t ret = this->backend_fh->Ftruncate(offset);
     return(ret);

--- a/src/LogicalFS/LogicalFD.h
+++ b/src/LogicalFS/LogicalFD.h
@@ -18,7 +18,9 @@ class Plfs_fd
                               pid_t pid, ssize_t *bytes_written) = 0;
         virtual plfs_error_t sync() = 0;
         virtual plfs_error_t sync(pid_t pid) = 0;
-        virtual plfs_error_t trunc(off_t offset) = 0;
+        /* XXX: containerfs is keeping us from removing ppip in trunc */
+        virtual plfs_error_t trunc(off_t offset,
+                                   struct plfs_physpathinfo *ppip) = 0;
         virtual plfs_error_t getattr(struct stat *stbuf, int sz_only) = 0;
         virtual plfs_error_t query(size_t *writers, size_t *readers,
                           size_t *bytes_written, bool *reopen) = 0;

--- a/src/LogicalFS/SmallFile/SmallFileFD.cpp
+++ b/src/LogicalFS/SmallFile/SmallFileFD.cpp
@@ -1,3 +1,4 @@
+
 #include <assert.h>
 #include "SmallFileFD.h"
 #include <SmallFileIndex.hxx>
@@ -9,7 +10,7 @@ Small_fd::open(struct plfs_physpathinfo * /* ppip */, int flags, pid_t pid,
     refs++;
     open_flags = flags & 0xf;
     open_by_pid = pid;
-    if (flags & O_TRUNC) trunc(0);
+    if (flags & O_TRUNC) trunc(0, NULL);
     return PLFS_SUCCESS;
 }
 
@@ -80,7 +81,7 @@ Small_fd::sync(pid_t /* pid */)
 }
 
 plfs_error_t
-Small_fd::trunc(off_t offset)
+Small_fd::trunc(off_t offset, struct plfs_physpathinfo *ppip)
 {
     plfs_error_t ret;
     if (open_flags == O_WRONLY || open_flags == O_RDWR) {

--- a/src/LogicalFS/SmallFile/SmallFileFD.h
+++ b/src/LogicalFS/SmallFile/SmallFileFD.h
@@ -28,7 +28,7 @@ class Small_fd : public Plfs_fd, public PLFSIndex
                       ssize_t *bytes_written);
         plfs_error_t sync();
         plfs_error_t sync(pid_t pid);
-        plfs_error_t trunc(off_t offset);
+        plfs_error_t trunc(off_t offset, struct plfs_physpathinfo *ppip);
         plfs_error_t getattr(struct stat *stbuf, int sz_only);
         plfs_error_t query(size_t *writers, size_t *readers, size_t *bytes_written,
                   bool *reopen);

--- a/src/plfs.cpp
+++ b/src/plfs.cpp
@@ -593,12 +593,23 @@ plfs_trunc(Plfs_fd *fd, const char *path, off_t offset, int open_file)
     plfs_error_t ret;
     const char *stripped_path;
     stripped_path = skipPrefixPath(path);
+
     if (fd) {
-        ret = fd->trunc(offset);
+        /*
+         * XXX: need to work towards getting rid of ppi in the
+         * fd->trunc() API (requires some work on container fs
+         * version of truncate code).
+         */ 
+        struct plfs_physpathinfo ppi;
+        ret = plfs_resolvepath(stripped_path, &ppi);
+        if (ret == 0) {
+            ret = fd->trunc(offset, &ppi);
+        } else {
+            ret = PLFS_EINVAL;
+        }
     }
     else{
         struct plfs_physpathinfo ppi;
-
         ret = plfs_resolvepath(stripped_path, &ppi);
         if (ret == PLFS_SUCCESS) {
             ret = ppi.mnt_pt->fs_ptr->trunc(&ppi, offset, open_file);


### PR DESCRIPTION
the containerfs truncate code isn't ready for this cleanup yet...
