### PR TITLE
Fix plfs.spec file and some compile errors for the unittest tool

### DIFF
--- a/plfs.spec
+++ b/plfs.spec
@@ -6,12 +6,6 @@
 %define pminor	4
 # patch version of PLFS. Uncomment if not zero
 #%define ppatch	0
-# major YAML version that is included in with PLFS
-%define ymajor	0
-# minor YAML version that is included in with PLFS
-%define yminor	5
-# patch YAML version that is included in with PLFS
-%define ypatch	0
 
 Name:		plfs
 Summary:	plfs - Parallel Log Structured File System
@@ -117,10 +111,6 @@ fi
 %{_libdir}/libplfs.a
 %{_libdir}/libplfs.so
 %{_libdir}/libplfs.so.%{pmajor}.%{pminor}
-%{_libdir}/libplfs-yaml-static.a
-%{_libdir}/libplfs-yaml.so
-%{_libdir}/libplfs-yaml.so.%{ymajor}.%{yminor}
-%{_libdir}/libplfs-yaml.so.%{ymajor}.%{yminor}.%{ypatch}
 %defattr(-,root,root,0644)
 %{_includedir}/plfs/COPYRIGHT.h
 %{_includedir}/plfs/mlogfacs.h
@@ -172,6 +162,10 @@ fi
 %{_mandir}/man7/plfs.7.gz
 
 %changelog
+* Wed Jul 17 2013 Zhang Jingwang <jingwang.zhang@emc.com>
+- Remove the YAML library packaged with PLFS. It will be included in the
+  PLFS library directly.
+
 * Thu May 23 2013 David Shrader <dshrader@lanl.gov>
 - use _mandir for directory to put man pages in instead of constructed path
   based on _prefix.

--- a/tests/smallfileunit.cpp
+++ b/tests/smallfileunit.cpp
@@ -89,7 +89,7 @@ WriterUnit::createfileTest() {
     int ret;
     NameOperation nop;
     list<NameOperation> to_be_verified;
-    IOSHandle *fh;
+    IOSHandle *fh = NULL;
 
     nop.fh = NULL;
     for (int i = 0; i < 100; i++) {
@@ -120,7 +120,7 @@ WriterUnit::removefileTest() {
     int ret;
     NameOperation nop;
     list<NameOperation> to_be_verified;
-    IOSHandle *fh;
+    IOSHandle *fh = NULL;
 
     nop.fh = NULL;
     for (int i = 0; i < 100; i++) {
@@ -156,7 +156,7 @@ WriterUnit::renamefileTest() {
     NameOperation nop;
     list<NameOperation> to_be_verified;
     char origin[256] = "OriginalFile";
-    IOSHandle *fh;
+    IOSHandle *fh = NULL;
 
     nop.fh = NULL;
     for (int i = 0; i < 100; i++) {
@@ -188,7 +188,7 @@ public:
     FileID fid;
     uint64_t offset;
     uint64_t length;
-    uint64_t physical_offset;
+    off_t physical_offset;
 };
 
 void
@@ -216,6 +216,7 @@ WriterUnit::writefileTest() {
     IOSHandle *fh;
 
     nop.fh = NULL;
+    iop.fh = NULL;
     iop.fid = 0;
     for (int i = 0; i < 100; i++) {
         char removed[256];


### PR DESCRIPTION
Fix the name of yaml static library in plfs.spec
Fix the mis-match types between the unittest tool and small file.
