### PR TITLE
Update to build rules - no more warnings for Release mode. Debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,10 +157,6 @@ if (BUILD_IOFSL)
    add_definitions(${FUSE_DEFINITIONS})
 endif (BUILD_IOFSL)
 
-#set compiler options
-set(CMAKE_CXX_FLAGS "-Wall -Werror -Wshadow -Wno-long-long -Wextra ${CMAKE_CXX_FLAGS}")
-set(CMAKE_C_FLAGS "-Wall -Werror -Wshadow -Wno-long-long -Wextra ${CMAKE_C_FLAGS}")
-
 #create the plfs library
 AUX_SOURCE_DIRECTORY(${PLFS_SOURCE_DIR} plfs_src_dir)
 AUX_SOURCE_DIRECTORY(${PLFS_SOURCE_DIR}/IOStore iostore)
@@ -358,6 +354,13 @@ endforeach(SOURCE)
 
 #test tools
 add_subdirectory("${PLFS_TESTS_DIR}")
+
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    #set devloper compiler options 
+    #ALL developers should build in debug mode by default
+    set(CMAKE_CXX_FLAGS "-Wall -Werror -Wshadow -Wno-long-long -Wextra ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_C_FLAGS "-Wall -Werror -Wshadow -Wno-long-long -Wextra ${CMAKE_C_FLAGS}")
+endif()
 
 #set up targets for make install
 INSTALL(TARGETS dcon findmesgbuf plfs_check_config plfs_flatten_index plfs_ls

--- a/README.developer
+++ b/README.developer
@@ -14,14 +14,18 @@ settings for their github account in Account Settings.
 
 4) Treat all build warnings as errors.
 No build warnings!
-Use the following flags when running cmake to make sure all warnings are being 
-treated as errors:
+Use the following flag when running cmake to make sure all warnings are being 
+treated as errors (the flags are set automatically in Debug mode):
 
--DCMAKE_C_FLAGS="-Wall -Werror -Wshadow"
--DCMAKE_CXX_FLAGS="-Wall -Werror -Wshadow"
+-DCMAKE_BUILD_TYPE="Debug"
 
-It should be noted that for the default build, these compile flags are enabled
-by default.
+It should be noted that for the default build without this flag PLFS will build
+in Release mode which has these warnings disabled. This is to allow for users
+to download and build PLFS on esoteric compilers we haven't tested on.
+
+***                                                                        ***
+If you commit code that only builds in Release mode you will be mocked. :)
+***                                                                        ***
 
 5) Everything must be code-reviewed before being committed to the master
 branch on github


### PR DESCRIPTION
has all warnings enabled by default. README.developer updated to reflect
this.
