### PR TITLE
Updated patches for OpenMPI and MPICH to only use PLFS CFLAGS/LDFLAGS

### DIFF
--- a/mpi_adio/README.patching
+++ b/mpi_adio/README.patching
@@ -70,10 +70,8 @@ to the ROMIO layer or the build system (such as MVAPICH2).
    setting some environment variables and running the configure script.
    a) for Open MPI, set the following env variables
 
-      LDFLAGS="-L/path/to/plfs/lib -Wl,-rpath=/path/to/plfs/lib -lplfs -lstdc++ -lpthread"
-      CFLAGS="-I/path/to/plfs/include"
-      CXXFLAGS="-I/path/to/plfs/include"
-      CCASFLAGS="-I/path/to/plfs/include"
+      AD_PLFS_LDFLAGS="-L/path/to/plfs/lib -dynamic -Wl,-rpath=/path/to/plfs/lib -lplfs -lstdc++ -lpthread"
+      AD_PLFS_CFLAGS="-I/path/to/plfs/include"
 
       Then, run configure with like this:
 
@@ -84,7 +82,7 @@ to the ROMIO layer or the build system (such as MVAPICH2).
       Open MPI's configure process. Please see the Open MPI documentation for
       further information.
 
-   b) for MPICH and its derivatives, set the LDFLAGS, CFLAGS, and CXXFLAGS
+   b) for MPICH and its derivatives, set the AD_PLFS_LDFLAGS and AD_PLFS_CFLAGS
       env variables as with Open MPI and use the following configure command
       (with possibly more parameters passed to configure such as --prefix):
 
@@ -99,10 +97,8 @@ cd openmpi-1.4.5
 patch -p1 < /path/to/plfs/mpi_adio/patches/openmpi/ompi-1.4.x-plfs-prep.patch
 patch -p1 < /path/to/plfs/mpi_adio/patches/openmpi/ompi-plfs.patch
 ./autogen.sh
-export LDFLAGS="-L/path/to/plfs/lib -Wl,-rpath=/path/to/plfs/lib -lplfs -lstdc++ -lpthread"
-export CFLAGS="-I/path/to/plfs/include"
-export CXXFLAGS="-I/path/to/plfs/include"
-export CCASFLAGS="-I/path/to/plfs/include"
+export AD_PLFS_LDFLAGS="-L/path/to/plfs/lib -dynamic -Wl,-rpath=/path/to/plfs/lib -lplfs -lstdc++ -lpthread"
+export AD_PLFS_CFLAGS="-I/path/to/plfs/include"
 export CPPFLAGS="-DROMIO_OPENMPI_14x"
 ./configure --with_io_romio_flags=--with-file-system=ufs+nfs+plfs --prefix=/path/to/mpi/install
 make
@@ -172,3 +168,6 @@ is necessary to manually copy in the correct Makefile:
 
 cp /path/to/plfs/source/mpi_adio/ad_plfs/Makefile.in.mpich2 \
   /path/to/MPICH2/source/src/mpi/romio/adio/ad_plfs/Makefile.in
+
+You may also need to specify CFLAGS and LDFLAGS env variables instead of 
+their AD_PLFS_ counterparts when building these older versions.

--- a/mpi_adio/ad_plfs/Makefile.am.ompi
+++ b/mpi_adio/ad_plfs/Makefile.am.ompi
@@ -19,6 +19,9 @@
 
 include $(top_srcdir)/Makefile.options
 
+libadio_plfs_la_LDFLAGS = $(AD_PLFS_LDFLAGS)
+libadio_plfs_la_CFLAGS = $(AD_PLFS_CFLAGS)
+
 noinst_LTLIBRARIES = libadio_plfs.la
 libadio_plfs_la_SOURCES = \
 	ad_plfs.c \

--- a/mpi_adio/ad_plfs/Makefile.mk.mpich
+++ b/mpi_adio/ad_plfs/Makefile.mk.mpich
@@ -9,6 +9,10 @@ if BUILD_AD_PLFS
 
 noinst_HEADERS += adio/ad_plfs/ad_plfs.h
 
+
+AM_LDFLAGS = $(AD_PLFS_LDFLAGS)
+AM_CFLAGS = $(AD_PLFS_CFLAGS)
+
 romio_other_sources +=              \
 	adio/ad_plfs/ad_plfs.c          \
 	adio/ad_plfs/ad_plfs_close.c    \


### PR DESCRIPTION
...when building the ad_plfs layer for ROMIO instead of globally.
Regression suite will need to be updated to reflect the new env variables.

This is in reference to: https://github.com/plfs/plfs-core/issues/312
