### PR TITLE
finish incomplete update of HDFSIOstore for the plfs_error_t changes.

### DIFF
--- a/src/IOStore/HDFS/HDFSIOStore.cpp
+++ b/src/IOStore/HDFS/HDFSIOStore.cpp
@@ -387,10 +387,11 @@ void hdfs_execute(const char *name, void *a, void (*hand)(void *ap)) {
 plfs_error_t HDFSIOStore::HDFSIOStore_xnew(char *phys_path,
                                            int *prelenp,
                                            char **bmpointp,
-                                           class HDFSIOStore **hiostore) {
+                                           class IOStore **hiostore) {
     char *p, *sl, *host, *col;
     int plen, port, rv;
     class HDFSIOStore *hio;
+    *hiostore = NULL;
 
     /* do some one-time module init stuff here, first */
     pthread_mutex_lock(&hst.gts_mux);
@@ -1208,7 +1209,8 @@ plfs_error_t HDFSIOSHandle::Size(off_t *ret_offset) {
  * @param bytes_written return byte count
  * @return PLFS_SUCCESS or PLFS_E* on error
  */
-plfs_error_t HDFSIOSHandle::Write(const void* buf, size_t len, ssize_t *bytes_written) {
+plfs_error_t HDFSIOSHandle::Write(const void* buf, size_t len, 
+                                  ssize_t *bytes_written) {
     ssize_t rv;
     rv = hdfsWrite_wrap(this->hfs, this->hfd, buf, len);
     *bytes_written = rv;

--- a/src/IOStore/HDFS/HDFSIOStore.h
+++ b/src/IOStore/HDFS/HDFSIOStore.h
@@ -16,19 +16,21 @@ class HDFSIOSHandle: public IOSHandle {
     HDFSIOSHandle(HDFSIOStore *newparent, hdfsFS newhfs,
                   hdfsFile newhfd, string newbpath);
 
-    int Fstat(struct stat *buf);
-    int Fsync();
-    int Ftruncate(off_t length);
-    int GetDataBuf(void **bufp, size_t length);
-    ssize_t Pread(void *buf, size_t count, off_t offset);
-    ssize_t Pwrite(const void *buf, size_t count, off_t offset);
-    ssize_t Read(void *buf, size_t length);
-    int ReleaseDataBuf(void *buf, size_t length);
-    off_t Size();
-    ssize_t Write(const void *buf, size_t len);
+    plfs_error_t Fstat(struct stat *buf);
+    plfs_error_t Fsync();
+    plfs_error_t Ftruncate(off_t length);
+    plfs_error_t GetDataBuf(void **bufp, size_t length);
+    plfs_error_t Pread(void *buf, size_t count, off_t offset, 
+                       ssize_t *bytes_read);
+    plfs_error_t Pwrite(const void *buf, size_t count, off_t offset, 
+                        ssize_t *bytes_written);
+    plfs_error_t Read(void *buf, size_t length, ssize_t *bytes_read);
+    plfs_error_t ReleaseDataBuf(void *buf, size_t length);
+    plfs_error_t Size(off_t *ret_offset);
+    plfs_error_t Write(const void *buf, size_t len, ssize_t *bytes_written);
 
  private:
-    int Close();
+    plfs_error_t Close();
     HDFSIOStore *parent;
     hdfsFS hfs;
     hdfsFile hfd;
@@ -40,10 +42,10 @@ class HDFSIOSDirHandle: public IOSDirHandle {
 
     HDFSIOSDirHandle(hdfsFS newfs, string newbpath, int &ret);
 
-    int Readdir_r(struct dirent *dst, struct dirent **dret);
+    plfs_error_t Readdir_r(struct dirent *dst, struct dirent **dret);
 
  private:
-    int Closedir();
+    plfs_error_t Closedir();
     hdfsFileInfo *infos;
     int numEntries;
     int curEntryNum;
@@ -51,28 +53,31 @@ class HDFSIOSDirHandle: public IOSDirHandle {
 
 class HDFSIOStore: public IOStore {
  public:
-    int Access(const char *path, int amode);
-    int Chmod(const char *path, mode_t mode);
-    int Chown(const char *path, uid_t owner, gid_t group);
-    int Lchown(const char *path, uid_t owner, gid_t group);
-    int Lstat(const char *path, struct stat *buf);
-    int Mkdir(const char *path, mode_t mode);
-    class IOSHandle *Open(const char *bpath, int flags, mode_t mode, int &ret);
-    class IOSDirHandle *Opendir(const char *bpath, int &ret);
-    int Rename(const char *from, const char *to);
-    int Rmdir(const char *path);
-    int Stat(const char *path, struct stat *buf);
-    int Statvfs(const char *path, struct statvfs *stbuf);
-    int Symlink(const char *name1, const char *name2);
-    ssize_t Readlink(const char *path, char *buf, size_t bufsiz);
-    int Truncate(const char *path, off_t length);
-    int Unlink(const char *path);
-    int Utime(const char *path, const utimbuf *timep);
+    plfs_error_t Access(const char *path, int amode);
+    plfs_error_t Chmod(const char *path, mode_t mode);
+    plfs_error_t Chown(const char *path, uid_t owner, gid_t group);
+    plfs_error_t Lchown(const char *path, uid_t owner, gid_t group);
+    plfs_error_t Lstat(const char *path, struct stat *buf);
+    plfs_error_t Mkdir(const char *path, mode_t mode);
+    plfs_error_t Open(const char *bpath, int flags, mode_t mode, 
+                      IOSHandle **ret_hand);
+    plfs_error_t Opendir(const char *bpath, class IOSDirHandle **ret_dhand);
+    plfs_error_t Rename(const char *from, const char *to);
+    plfs_error_t Rmdir(const char *path);
+    plfs_error_t Stat(const char *path, struct stat *buf);
+    plfs_error_t Statvfs(const char *path, struct statvfs *stbuf);
+    plfs_error_t Symlink(const char *name1, const char *name2);
+    plfs_error_t Readlink(const char *path, char *buf, size_t bufsiz,
+                          ssize_t *readlen);
+    plfs_error_t Truncate(const char *path, off_t length);
+    plfs_error_t Unlink(const char *path);
+    plfs_error_t Utime(const char *path, const utimbuf *timep);
 
-    static class HDFSIOStore *HDFSIOStore_xnew(char *phys_path, int *prelenp,
-                                               char **bmpointp);
+    static plfs_error_t HDFSIOStore_xnew(char *phys_path, int *prelenp,
+                                         char **bmpointp,
+                                         class IOStore **hiostore);
     static int HDFS_Check(class HDFSIOStore *hio);
-    int HDFS_Probe();
+    plfs_error_t HDFS_Probe();
     
  private:
     hdfsFS hfs;


### PR DESCRIPTION
Fixes to make HDFS IOStore compile with the new plfs_error_t API changes.
